### PR TITLE
Fix bug there prefix_package option has no effect on emitted filenames when input protofiles contains a path component

### DIFF
--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -389,7 +389,7 @@ let parse_proto_file ~params scope
   Code.append implementation implementation';
   Code.emit implementation `None "";
 
-  let base_name = Filename.remove_extension name in
+  let base_name = Filename.basename name |> Filename.remove_extension in
   let output_file_name = match params.prefix_output_with_package with
     | false -> sprintf "%s.ml" base_name
     | true ->
@@ -402,4 +402,4 @@ let parse_proto_file ~params scope
       sprintf "%s_%s.ml" prefix base_name
   in
 
-  (output_file_name), implementation
+  output_file_name, implementation

--- a/src/plugin/protoc_gen_ocaml.ml
+++ b/src/plugin/protoc_gen_ocaml.ml
@@ -31,18 +31,18 @@ let write response =
 let parse_request Plugin.CodeGeneratorRequest.{file_to_generate = files_to_generate; parameter = parameters; proto_file = proto_files; compiler_version = _} =
   let params = Parameters.parse (Option.value ~default:"" parameters) in
   let target_proto_files = List.filter ~f:(fun Descriptor.FileDescriptorProto.{name; _} ->
-      List.mem ~set:files_to_generate (Option.value_exn name)
-    ) proto_files
+    List.mem ~set:files_to_generate (Option.value_exn name)
+  ) proto_files
   in
   let scope = Scope.init ~params proto_files in
   let result =
     List.map ~f:(fun (proto_file : Descriptor.FileDescriptorProto.t) ->
-        let scope = Scope.for_descriptor ~params scope proto_file in
-        Emit.parse_proto_file ~params scope proto_file
-      ) target_proto_files
+      let scope = Scope.for_descriptor ~params scope proto_file in
+      Emit.parse_proto_file ~params scope proto_file
+    ) target_proto_files
     |> List.map ~f:(fun (name, code) ->
-        (Filename.basename name, code)
-      )
+      (name, code)
+    )
   in
   (match params.debug with
    | true -> List.iter ~f:(fun (_, code) -> Printf.eprintf "%s\n%!" (Code.contents code)) result

--- a/test/dune
+++ b/test/dune
@@ -88,6 +88,23 @@
        "--plugin=protoc-gen-ocaml=%{plugin}"
        "--ocaml_out=open=Google_types_pp;open=Test_runtime;prefix_output_with_package=true;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
 
+(rule
+ (targets
+   test_include_a_message.ml
+   test_include_b_message.ml
+ )
+ (deps
+  (:plugin ../src/plugin/protoc_gen_ocaml.exe)
+  (:proto
+    test_include_a/message.proto
+    test_include_b/message.proto
+  )
+ )
+ (action
+  (run protoc -I %{read-lines:google_include} -I .
+       "--plugin=protoc-gen-ocaml=%{plugin}"
+       "--ocaml_out=open=Google_types_pp;open=Test_runtime;prefix_output_with_package=true;annot=[@@deriving show { with_path = false }, eq]:." %{proto})))
+
 
 (rule
  (targets int_types_native.ml int_types_native_proto2.ml)

--- a/test/test_include_a/message.proto
+++ b/test/test_include_a/message.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package test_include_a;
+
+message M { }

--- a/test/test_include_b/message.proto
+++ b/test/test_include_b/message.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "test_include_a/message.proto";
+package test_include_b;
+message M {
+  test_include_a.M m = 1;
+}


### PR DESCRIPTION
This fixes a problem where generated files were not correctly prefixed when the package prefix option was enabled

closes #7 
