### PR TITLE
Set package name in a rpc service to None if its not defined in a package scope

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@
 generating uncompilable code. (#21)
 - [x] Fix codegen bug for messages with out fields and setting
 singleton_records = true (#20)
+- [x] In Services, the package field is now correctly set to None if
+      the service if not defined in a package scope (#24)
 
 ### Misc changes
 - [x] Unify serialization and deserialization spec and optimize oneof
@@ -25,7 +27,7 @@ string` which will only return the full protobuf name
 (`*` indicates breaking change)
 
 ### Notes
-  `Message.name: unit -> string` has been renamed to `Message.name:
+  `Message.name': unit -> string` has been renamed to `Message.name:
   unit -> string`, and is now contains the fully qualified protobuf
   message name. Before the name was the ocaml module name of the
   message.

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -478,9 +478,9 @@ let get_name_exn t name =
   get_name t name
 
 let get_package_name t =
-  match t.proto_path with
-  | _ :: xs -> List.rev xs |> String.concat ~sep:"." |> Option.some
-  | _ -> None
+  match List.tl t.proto_path with
+  | [] -> None
+  | xs -> List.rev xs |> String.concat ~sep:"." |> Option.some
 
 let get_module_name ~filename t =
   StringMap.find_opt filename t.file_names

--- a/test/service_empty_package_test.ml
+++ b/test/service_empty_package_test.ml
@@ -1,0 +1,13 @@
+module Call = Service_empty_package.Test.Call
+
+let%expect_test "service attributes" =
+  Printf.printf "name: %s\n" Call.name;
+  Printf.printf "package_name: %s\n" (Option.value ~default:"<none>"  Call.package_name);
+  Printf.printf "service_name: %s\n" Call.service_name;
+  Printf.printf "method_name: %s\n" Call.method_name;
+  ();
+  [%expect {|
+    name: /Test/Call
+    package_name: <none>
+    service_name: Test
+    method_name: Call |}]


### PR DESCRIPTION
Closes #24 