### PR TITLE
Copy comments from the protobuf file into autogenerated code

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - [x] Support special json mapping for google types (#9)
 - [x] Add deprecation annotations for deprecated fields, services etc (#8)
 - [x] Add option to prefix generated files with their package name
+- [x] Copy documentation from proto files into generated ocaml bindings
 
 ### Bug fixes
 - [x] Fix file output name if files contains a '-'

--- a/src/ocaml_protoc_plugin/json.ml
+++ b/src/ocaml_protoc_plugin/json.ml
@@ -11,7 +11,7 @@ type t = [
   | `List of t list
 ]
 
-let rec to_string = function
+let rec to_string: t -> string = function
   | `Null -> "null"
   | `Bool b -> string_of_bool b
   | `Int i -> string_of_int i

--- a/src/plugin/code.ml
+++ b/src/plugin/code.ml
@@ -64,28 +64,22 @@ let map_comments comments =
   comments
   |> List.map ~f:(trim_end ~char:'\n')
   |> String.concat ~sep:"\n\n"
+  |> String.to_seq
+  |> Seq.map (function
+    | '{' | '}' | '[' | ']' | '@' | '\\' as ch -> Printf.sprintf "\\%c" ch
+    | ch -> Printf.sprintf "%c" ch
+  )
+  |> List.of_seq
+  |> String.concat ~sep:""
 
-
-let emit_comment ?(id="") t =
-  let emit_comment str =
-    String.to_seq str
-    |> Seq.map (function
-      | '{' | '}' | '[' | ']' | '@' as ch -> Printf.sprintf "\\%c" ch
-      | ch -> Printf.sprintf "%c" ch
-    )
-    |> List.of_seq
-    |> String.concat ~sep:""
-    |> emit t `None "%s"
-  in
-
-  function
+let emit_comment ?(id="") t = function
   | [] -> ()
   | comments ->
     emit t `None "";
     emit t `Begin "(** %s" id;
     map_comments comments
     |> String.split_on_char ~sep:'\n'
-    |> List.iter ~f:emit_comment;
+    |> List.iter ~f:(emit t `None "%s");
     emit t `End "*)";
     ()
 
@@ -107,7 +101,7 @@ let append_comments ~comments str =
   | [] -> str
   | comments ->
     let comment = map_comments comments in
-    Printf.sprintf "%s (** %s *)" str (String.trim comment)
+    Printf.sprintf "%s (** %s *) " str (String.trim comment)
 
 let contents t =
   List.map ~f:(Printf.sprintf "%s") (List.rev t.code)

--- a/src/plugin/code.ml
+++ b/src/plugin/code.ml
@@ -15,12 +15,12 @@ let decr t =
   | false -> failwith "Cannot decr indentation level at this point"
 
 let trim_end ~chars s =
-  let chars = String.to_seq chars in
+  let chars = String.to_seq chars |> List.of_seq in
   let len = String.length s in
   let rcount s =
     let rec inner = function
       | 0 -> len
-      | n when Seq.exists (fun x -> x = s.[n - 1]) chars -> inner (n - 1)
+      | n when List.mem s.[n - 1] ~set:chars -> inner (n - 1)
       | n -> len - n
     in
     inner len

--- a/src/plugin/comment_db.ml
+++ b/src/plugin/comment_db.ml
@@ -1,0 +1,65 @@
+open StdLabels
+open MoreLabels
+open Spec.Descriptor.Google.Protobuf
+
+type element =
+  | Message | Field
+  | Enum | Enum_value
+  | Oneof
+  | Service | Method
+  | Extension
+  | File
+  | Unknown
+
+let element_of_int ~context = function
+  | 4 when context = File -> Message
+  | 3 when context = Message -> Message
+
+  | 5 when context = File -> Enum
+  | 4 when context = Message -> Enum
+  | 2 when context = Enum -> Enum_value
+
+  | 8 when context = Message -> Oneof
+  | 2 when context = Message -> Field
+
+  | 6 when context = File -> Service
+  | 2 when context = Service -> Method
+
+  | 7 when context = File -> Extension
+  | 6 when context = Message -> Extension
+
+  | _ -> Unknown
+
+type path = (element * int) list
+module Db = Map.Make(struct type t = path let compare = compare end)
+
+type comment = string option
+type document = { leading: comment; trailing: comment; detatched: string list }
+type t = document Db.t
+
+let make: SourceCodeInfo.t option -> t = fun source_code_info ->
+  let source_code_info = Option.value ~default:[] source_code_info in
+  (* It would be simpler if I could peel off each layer as I traverse *)
+  (* At least the path should be reversed, as its easier to append *)
+  (* And the path should be in pairs???? - That is not what the documentation says *)
+
+  (* For each source code info field, parse the list. Need to remeber the current context *)
+  (* Remember, we dont want comments for individual names *)
+
+  let rec map_location ~context = function
+    | field_id :: number :: rest ->
+      let element = element_of_int ~context field_id in
+      (element, number) :: map_location ~context:element rest
+    | [ _ ] | [] -> []
+  in
+
+  List.fold_left ~init:Db.empty ~f:(fun db location ->
+    let path = map_location ~context:File location.SourceCodeInfo.Location.path in
+    let element =
+      { leading = location.SourceCodeInfo.Location.leading_comments;
+        trailing = location.SourceCodeInfo.Location.trailing_comments;
+        detatched = location.SourceCodeInfo.Location.leading_detached_comments;
+      }
+    in
+    Db.add ~key:path ~data:element db
+  ) source_code_info

--- a/src/plugin/comment_db.ml
+++ b/src/plugin/comment_db.ml
@@ -9,10 +9,25 @@ type element =
   | Service | Method
   | Extension
   | File
-  | Unknown
+  | Option
+  | Unknown of element * int
+
+let rec string_of_element = function
+  | Message -> "Message"
+  | Field -> "Field"
+  | Enum -> "Enum"
+  | Enum_value -> "Enum_value"
+  | Oneof -> "Oneof"
+  | Service -> "Service"
+  | Method -> "Method"
+  | Extension -> "Extension"
+  | File -> "File"
+  | Option -> "Option"
+  | Unknown (ctx, n) -> Printf.sprintf "Unknown(%s, %d)" (string_of_element ctx) n
 
 let element_of_int ~context = function
   | 4 when context = File -> Message
+  | 8 when context = File -> Option
   | 3 when context = Message -> Message
 
   | 5 when context = File -> Enum
@@ -28,38 +43,115 @@ let element_of_int ~context = function
   | 7 when context = File -> Extension
   | 6 when context = Message -> Extension
 
-  | _ -> Unknown
+  | n -> Unknown (context, n)
 
 type path = (element * int) list
-module Db = Map.Make(struct type t = path let compare = compare end)
+
+let string_of_path path =
+  List.map ~f:(fun (e, i) ->
+    let e_str = string_of_element e in
+    Printf.sprintf "(%s, %d)" e_str i
+  ) path
+  |> String.concat ~sep:"; "
+  |> Printf.sprintf "[ %s ]"
+
 
 type comment = string option
-type document = { leading: comment; trailing: comment; detatched: string list }
-type t = document Db.t
+type comments = { leading: comment; trailing: comment; detatched: string list }
 
-let make: SourceCodeInfo.t option -> t = fun source_code_info ->
+module Code_info_map = Map.Make(struct type t = path let compare = compare end)
+type code_info_map = comments Code_info_map.t
+
+type t = comments Utils.StringMap.t
+
+let make_code_info_map: SourceCodeInfo.t option -> code_info_map = fun source_code_info ->
   let source_code_info = Option.value ~default:[] source_code_info in
-  (* It would be simpler if I could peel off each layer as I traverse *)
-  (* At least the path should be reversed, as its easier to append *)
-  (* And the path should be in pairs???? - That is not what the documentation says *)
-
-  (* For each source code info field, parse the list. Need to remeber the current context *)
-  (* Remember, we dont want comments for individual names *)
 
   let rec map_location ~context = function
     | field_id :: number :: rest ->
       let element = element_of_int ~context field_id in
       (element, number) :: map_location ~context:element rest
-    | [ _ ] | [] -> []
+    | [ field_id ] -> [ Field, field_id ]
+    | [] -> []
   in
 
-  List.fold_left ~init:Db.empty ~f:(fun db location ->
-    let path = map_location ~context:File location.SourceCodeInfo.Location.path in
-    let element =
-      { leading = location.SourceCodeInfo.Location.leading_comments;
-        trailing = location.SourceCodeInfo.Location.trailing_comments;
-        detatched = location.SourceCodeInfo.Location.leading_detached_comments;
-      }
-    in
-    Db.add ~key:path ~data:element db
-  ) source_code_info
+  let map =
+    List.fold_left ~init:Code_info_map.empty ~f:(fun db location ->
+      match location with
+      | SourceCodeInfo.Location.{ leading_comments = None; trailing_comments = None; leading_detached_comments = []; _ } -> db
+      | SourceCodeInfo.Location.{ leading_comments = leading; trailing_comments = trailing; leading_detached_comments = detatched; _ } ->
+        let path = map_location ~context:File location.SourceCodeInfo.Location.path in
+        let element = { leading; trailing; detatched } in
+        Code_info_map.add ~key:path ~data:element db
+    ) source_code_info
+  in
+  map
+
+let concat_mapi ~f lst =
+  let vs = List.mapi ~f lst in
+  List.concat vs
+
+let prepend_path ~tpe ~index ~name lst =
+  let path = tpe, index in
+  (path :: [], name) :: List.map ~f:(fun (p, n) ->
+    path :: p, Printf.sprintf "%s.%s" name n
+  ) lst
+
+let traverse_field index FieldDescriptorProto.{ name; _ } =
+  let name = Option.value_exn name in
+  [Field, index], name
+
+let traverse_extension index FieldDescriptorProto.{ name; _ } =
+  let name = Option.value_exn name in
+  [Extension, index], name
+
+let traverse_service_method index MethodDescriptorProto.{ name; _ } =
+  let name = Option.value_exn name in
+  [Method, index], name
+
+let traverse_service index ServiceDescriptorProto.{ name; method'; _ } =
+  let name = Option.value_exn name in
+  let values = List.mapi ~f:traverse_service_method method' in
+  prepend_path ~tpe:Enum ~index ~name values
+
+let traverse_enum_value index EnumValueDescriptorProto.{ name; _ } =
+  let name = Option.value_exn name in
+  [Enum_value, index], name
+
+let traverse_enum_type index EnumDescriptorProto.{ name; value; _ } =
+  let name = Option.value_exn name in
+  let values = List.mapi ~f:traverse_enum_value value in
+  prepend_path ~tpe:Enum ~index ~name values
+
+let rec traverse_message index DescriptorProto.{ name; field; nested_type; enum_type; extension; _ } =
+  let name = Option.value_exn name in
+  let fields = List.mapi ~f:traverse_field field in
+  let sub_messages = concat_mapi ~f:traverse_message nested_type in
+  let extensions = List.mapi ~f:traverse_extension extension in
+  let enums = concat_mapi ~f:traverse_enum_type enum_type in
+
+  (fields @ sub_messages @ extensions @ enums)
+  |> prepend_path ~tpe:Message ~index ~name
+
+let traverse FileDescriptorProto.{ package; enum_type; service; extension; message_type; _ } =
+  let package = match package with
+    | Some package -> Printf.sprintf ".%s" package
+    | None -> ""
+  in
+  let enums = concat_mapi ~f:traverse_enum_type enum_type in
+  let services = concat_mapi ~f:traverse_service service in
+  let messages = concat_mapi ~f:traverse_message message_type in
+  let extensions = List.mapi ~f:traverse_extension extension in
+  (enums @ services @ messages @ extensions )
+  |> List.map ~f:(fun (path, name) -> path, Printf.sprintf "%s.%s" package name)
+
+
+(** Traverse the full filedescriptor proto to construct proto_name -> comments mapping *)
+let make: FileDescriptorProto.t -> t = fun filedescriptor ->
+  let code_info_map = make_code_info_map filedescriptor.source_code_info in
+  traverse filedescriptor
+  |> List.fold_left ~init:Utils.StringMap.empty ~f:(fun t (path, name) ->
+    match Code_info_map.find_opt path code_info_map with
+    | Some comments -> Utils.StringMap.add ~key:name ~data:comments t
+    | None -> t
+  )

--- a/src/plugin/dune
+++ b/src/plugin/dune
@@ -1,7 +1,7 @@
 (executable
  (name protoc_gen_ocaml)
  (public_name protoc-gen-ocaml)
- (libraries spec)
+ (libraries spec str)
  (package ocaml-protoc-plugin)
  (instrumentation (backend bisect_ppx))
 )

--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -34,7 +34,7 @@ let emit_enum_type ~scope ~params
       |> Code.append_deprecaton_if `Attribute ~deprecated
     in
     Code.emit t `None "| %s" enum_name;
-    Code.emit_comment ~deprecated ~position:`Trailing t (Scope.get_comments ?name scope)
+    Code.emit_comment ~position:`Trailing t (Scope.get_comments ?name scope)
   ) values;
   Code.emit t `End "%s" params.Parameters.annot;
 

--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -265,8 +265,7 @@ let rec emit_message ~params ~syntax ~scope
         Types.make ~params ~syntax ~is_cyclic ~extension_ranges ~scope ~fields oneof_decls
       in
       Code.emit signature `None "type t = %s%s" type' params.annot;
-      Code.emit signature `None "type make_t = %s" default_constructor_sig;
-      Code.emit signature `None "val make: make_t";
+      Code.emit signature `None "val make: %s" default_constructor_sig;
       Code.emit signature `None "(** Helper function to generate a message using default values *)\n";
 
       Code.emit signature `None "val to_proto: t -> Runtime'.Writer.t";
@@ -283,6 +282,7 @@ let rec emit_message ~params ~syntax ~scope
       Code.emit signature `None "(** Fully qualified protobuf name of this message *)\n";
 
       Code.emit signature `None "(**/**)";
+      Code.emit signature `None "type make_t = %s" default_constructor_sig;
       Code.emit signature `None "val merge: t -> t -> t";
       Code.emit signature `None "val to_proto': Runtime'.Writer.t -> t -> unit";
       Code.emit signature `None "val from_proto_exn: Runtime'.Reader.t -> t";

--- a/src/plugin/emit.ml
+++ b/src/plugin/emit.ml
@@ -156,6 +156,7 @@ let emit_extension ~scope ~params field =
   Code.emit signature `None "val get: %s -> (%s, [> Runtime'.Result.error]) result" extendee_type c.typestr;
   Code.emit signature `None "val set: %s -> %s -> %s" extendee_type c.typestr extendee_type;
 
+  Code.emit implementation `None "module This = %s" module_name;
   Code.emit implementation `None "type t = %s %s" c.typestr params.annot;
   Code.emit implementation `None "let get_exn extendee = Runtime'.Extensions.get Runtime'.Spec.(%s) (extendee.%s)" c.spec_str extendee_field ;
   Code.emit implementation `None "let get extendee = Runtime'.Result.catch (fun () -> get_exn extendee)";

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -146,3 +146,12 @@ let get_module_name ~filename t =
 let is_cyclic t =
   let Type_tree.{ cyclic; _ } = StringMap.find (get_proto_path t) t.type_db in
   cyclic
+
+
+let get_comments ?name t =
+  let path =
+    let path = get_proto_path t in
+    Option.value_map ~default:path ~f:(fun name -> Printf.sprintf "%s.%s" path name) name
+  in
+  StringMap.find_opt path t.type_db
+  |> Option.value_map ~default:[] ~f:(fun Type_tree.{ comments; _ } -> comments)

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -88,60 +88,41 @@ let get_scoped_name ?postfix t name =
   let name = Option.value_exn ~message:"Does not contain a name" name in
   let Type_tree.{ ocaml_name; module_name; _ } = StringMap.find name t.type_db in
 
-  (* If the name to be found is in another module, then stop looking *)
-  let type_name =
-    (* Printf.eprintf "Current scope: %s. Look for %s\n" (String.concat ~sep:"." (List.rev t.proto_path)) name; *)
-    let rec resolve path_rev module_name =
-      let path = "" :: List.rev_append path_rev module_name |> String.concat ~sep:"." in
-      (* Printf.eprintf "%s" path; *)
-      match StringMap.mem path t.type_db with
-      | true ->
-        (* Printf.eprintf " -> Some %s\n" path; *)
-        Some path
-      | false -> begin
-          match path_rev with
-          | [] ->
-            (* Printf.eprintf " -> None\n"; *)
-            None
-          | _ :: ps ->
-            (* Printf.eprintf " -> "; *)
-            resolve ps module_name
-        end
-    in
-    (* We are looking for 'name' *)
-    let search name =
-      let paths = String.split_on_char ~sep:'.' name |> List.rev in
-      let rec inner path paths =
-        (* Printf.eprintf "Resolve: "; *)
-        let p = resolve t.proto_path path in
-        match p with
-        | Some path' when path' = name ->
-          (* Found! *)
-          String.split_on_char ~sep:'.' ocaml_name
-          |> List.rev
-          |> take (List.length path)
-          |> List.rev
-          |> String.concat ~sep:"."
-
-        | _  -> begin match paths with
-          | p :: paths -> inner (p :: path) paths
-          | [] -> failwith_f "Unable to reference '%s'. This is due to a limitation in the Ocaml mappings. To work around this limitation make sure to use a unique package name" name
-        end
-      in
-      inner [] paths
-    in
-    match t.module_name = module_name with
-    | true-> search name
-    | false -> Printf.sprintf "%s.%s.%s" import_module_name module_name ocaml_name
+  let rec resolve path_rev module_name =
+    let path = "" :: List.rev_append path_rev module_name |> String.concat ~sep:"." in
+    match StringMap.mem path t.type_db, path_rev with
+    | true, _ ->  Some path
+    | false, [] -> None
+    | false, _ :: ps -> resolve ps module_name
   in
-
+  let search name =
+    let paths = String.split_on_char ~sep:'.' name |> List.rev in
+    let rec inner path paths =
+      let p = resolve t.proto_path path in
+      match p, paths with
+      | Some path', _ when path' = name ->
+        String.split_on_char ~sep:'.' ocaml_name
+        |> List.rev
+        |> take (List.length path)
+        |> List.rev
+        |> String.concat ~sep:"."
+        |> Option.some
+      | _, p :: paths -> inner (p :: path) paths
+      | _, [] -> None
+    in
+    inner [] paths
+  in
+  let type_name =
+    match t.module_name = module_name with
+    | true -> search name
+    | false -> Printf.sprintf "%s.%s.%s" import_module_name module_name ocaml_name |> Option.some
+  in
   match postfix, type_name with
-  | postfix, _ when get_proto_path t = name ->
-    Option.value ~default:"This" postfix
-  | Some postfix, "" -> postfix
-  | None, "" -> this_module_alias
-  | None, type_name -> type_name
-  | Some postfix, type_name -> Printf.sprintf "%s.%s" type_name postfix
+  | Some postfix, Some "" -> postfix
+  | None, Some "" -> this_module_alias
+  | None, Some type_name -> type_name
+  | Some postfix, Some type_name -> Printf.sprintf "%s.%s" type_name postfix
+  | _, None -> failwith_f "Unable to reference '%s'. This is due to a limitation in the Ocaml mappings. To work around this limitation make sure to use a unique package name" name
 
 let get_name t name =
   let path = Printf.sprintf "%s.%s" (get_proto_path t) name in

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -136,6 +136,8 @@ let get_scoped_name ?postfix t name =
   in
 
   match postfix, type_name with
+  | postfix, _ when get_proto_path t = name ->
+    Option.value ~default:"This" postfix
   | Some postfix, "" -> postfix
   | None, "" -> this_module_alias
   | None, type_name -> type_name

--- a/src/plugin/scope.ml
+++ b/src/plugin/scope.ml
@@ -1,7 +1,6 @@
-open StdLabels
-open MoreLabels
-
-open Utils
+open !StdLabels
+open !MoreLabels
+open !Utils
 
 let dump_ocaml_names = false
 let dump_type_tree = false

--- a/src/plugin/scope.mli
+++ b/src/plugin/scope.mli
@@ -38,3 +38,6 @@ val get_proto_path: t -> string
 
 (** Return the mapped module name for a protobuf file *)
 val get_module_name: filename:string -> t -> string
+
+(** Get comments for a given proto identifier (path) *)
+val get_comments: ?name:string -> t -> string list

--- a/src/plugin/type_tree.ml
+++ b/src/plugin/type_tree.ml
@@ -1,8 +1,9 @@
-open StdLabels
+open !StdLabels
 open !MoreLabels
+open !Utils
+
 open Spec.Descriptor.Google.Protobuf
 
-open Utils
 
 type t = { name: string;
            types: t list;

--- a/src/plugin/types.ml
+++ b/src/plugin/types.ml
@@ -630,8 +630,8 @@ let make ~params ~syntax ~is_cyclic ~extension_ranges ~scope ~fields oneof_decls
   let has_extensions = match extension_ranges with [] -> false | _ -> true in
 
   let field_info =
-    List.rev_map ~f:(fun { name; type'; _} -> (Scope.get_name scope name, (string_of_type type', type'.deprecated)) ) ts
-    |> prepend ~cond:has_extensions ("extensions'", ("Runtime'.Extensions.t", false))
+    List.rev_map ~f:(fun { name; type'; _} -> (Scope.get_name scope name, (string_of_type type', type'.deprecated, name)) ) ts
+    |> prepend ~cond:has_extensions ("extensions'", ("Runtime'.Extensions.t", false, ""))
     |> List.rev
   in
 
@@ -684,7 +684,7 @@ let make ~params ~syntax ~is_cyclic ~extension_ranges ~scope ~fields oneof_decls
     | true -> "unit"
     | false ->
       List.map ~f:snd field_info
-      |> List.map ~f:fst
+      |> List.map ~f:(fun (fst, _, _) -> fst)
       |> String.concat ~sep:" * "
       |> sprintf "(%s)"
       |> Code.append_deprecaton_if ~deprecated:has_deprecated_fields `Item
@@ -693,11 +693,13 @@ let make ~params ~syntax ~is_cyclic ~extension_ranges ~scope ~fields oneof_decls
   let type' = match t_as_tuple || field_info = [] with
     | true -> tuple_type
     | false ->
-      List.map ~f:(fun (name, (type', deprecated)) ->
+      List.map ~f:(fun (name, (type', deprecated, proto_name)) ->
         sprintf "%s: %s" name type'
         |> Code.append_deprecaton_if ~deprecated `Attribute
+        |> sprintf "%s; "
+        |> Code.append_comments ~comments:(Scope.get_comments ~name:proto_name scope)
       ) field_info
-      |> String.concat ~sep:"; "
+      |> String.concat ~sep:""
       |> sprintf "{ %s }"
   in
 

--- a/src/plugin/types.ml
+++ b/src/plugin/types.ml
@@ -251,7 +251,7 @@ let spec_of_enum ~scope type_name default =
       default_value
     | None ->
       (* We could just get the default from the module *)
-      sprintf "(%s.from_int_exn 0)" (Scope.get_scoped_name scope type_name);
+      (Scope.get_scoped_name scope ~postfix:"from_int_exn 0" type_name);
       (* Scope.get_scoped_enum_name scope type_name *)
   in
   Enum { type'; module_name; default }

--- a/src/plugin/types.ml
+++ b/src/plugin/types.ml
@@ -679,7 +679,9 @@ let make ~params ~syntax ~is_cyclic ~extension_ranges ~scope ~fields oneof_decls
       |> sprintf "{ %s }"
   in
 
+  (* Only add comments if the arity of the tuple is > 1. *)
   let tuple_type =
+    let arity = List.length field_info in
     let comments =
       List.filter_map ~f:(fun (name, (_, _, _proto_name)) ->
         let comment_lines =
@@ -688,7 +690,8 @@ let make ~params ~syntax ~is_cyclic ~extension_ranges ~scope ~fields oneof_decls
         in
         match (String.concat ~sep:"\n" comment_lines |> String.trim) with
         | "" -> None
-        | comment -> sprintf "@param %s %s" name comment |> Option.some
+        | comment when arity > 1 -> sprintf "@param %s %s" name comment |> Option.some
+        | comment -> comment |> Option.some
       ) field_info
       |> String.concat ~sep:"\n\n"
       |> function "" -> "" | comment -> sprintf "\n(**\n%s\n*)\n" comment
@@ -711,7 +714,7 @@ let make ~params ~syntax ~is_cyclic ~extension_ranges ~scope ~fields oneof_decls
         sprintf "\t%s: %s" name type'
         |> Code.append_deprecaton_if ~deprecated `Attribute
         |> sprintf "%s;"
-        |> Code.append_comments ~deprecated ~comments:(Scope.get_comments ~name:proto_name scope)
+        |> Code.append_comments ~comments:(Scope.get_comments ~name:proto_name scope)
       ) field_info
       |> String.concat ~sep:"\n"
       |> sprintf "{\n%s\n}"

--- a/src/plugin/utils.ml
+++ b/src/plugin/utils.ml
@@ -7,9 +7,13 @@ let failwith_f fmt =
 module String = struct
   include String
 
+  let starts_with ~prefix s =
+    let regex = Str.regexp ("^" ^ Str.quote prefix) in
+    Str.string_match regex s 0
+
   let trim_end ~chars s =
-    let chars = String.to_seq chars |> List.of_seq in
-    let len = String.length s in
+    let chars = to_seq chars |> List.of_seq in
+    let len = length s in
     let rcount s =
       let rec inner = function
         | 0 -> len
@@ -20,7 +24,7 @@ module String = struct
     in
     match rcount s with
     | 0 -> s
-    | n -> String.sub ~pos:0 ~len:(String.length s - n) s
+    | n -> sub ~pos:0 ~len:(length s - n) s
 
   let starts_with_regex ~regex str =
     let regex = Str.regexp ("^" ^ regex) in
@@ -44,9 +48,9 @@ module List = struct
 
   let group ~f lines =
     let prepend acc group last =
-      let acc = match List.is_empty group with
+      let acc = match is_empty group with
         | true -> acc
-        | false -> (last, List.rev group) :: acc
+        | false -> (last, rev group) :: acc
       in
       acc
     in
@@ -55,7 +59,7 @@ module List = struct
         inner acc (x :: group) last xs
       | x :: xs ->
         inner (prepend acc group last) [x] (not last) xs
-      | [] -> List.rev (prepend acc group last)
+      | [] -> rev (prepend acc group last)
     in
     inner [] [] false lines
 

--- a/src/plugin/utils.ml
+++ b/src/plugin/utils.ml
@@ -4,10 +4,67 @@ open MoreLabels
 let failwith_f fmt =
   Printf.ksprintf (fun s -> failwith s) fmt
 
+module String = struct
+  include String
+
+  let trim_end ~chars s =
+    let chars = String.to_seq chars |> List.of_seq in
+    let len = String.length s in
+    let rcount s =
+      let rec inner = function
+        | 0 -> len
+        | n when List.mem s.[n - 1] ~set:chars -> inner (n - 1)
+        | n -> len - n
+      in
+      inner len
+    in
+    match rcount s with
+    | 0 -> s
+    | n -> String.sub ~pos:0 ~len:(String.length s - n) s
+
+  let starts_with_regex ~regex str =
+    let regex = Str.regexp ("^" ^ regex) in
+    Str.string_match regex str 0
+
+  let replace ~substring ~f =
+    let regexp = Str.regexp (Str.quote substring) in
+    Str.global_substitute regexp f
+
+end
+
+module List = struct
+  include List
+  let rec drop_while ~f = function
+    | x :: xs when f x -> drop_while ~f xs
+    | xs -> xs
+
+  let is_empty = function
+    | [] -> true
+    | _ -> false
+
+  let group ~f lines =
+    let prepend acc group last =
+      let acc = match List.is_empty group with
+        | true -> acc
+        | false -> (last, List.rev group) :: acc
+      in
+      acc
+    in
+    let rec inner acc group last = function
+      | x :: xs when f x = last || x = "" ->
+        inner acc (x :: group) last xs
+      | x :: xs ->
+        inner (prepend acc group last) [x] (not last) xs
+      | [] -> List.rev (prepend acc group last)
+    in
+    inner [] [] false lines
+
+end
+
 module StringMap = struct
   include Map.Make(String)
 
-  (** Fail with an error if the key already exists *)
+(** Fail with an error if the key already exists *)
   let add_uniq ~key ~data map =
     update ~key ~f:(function
       | None -> Some data

--- a/src/spec/descriptor.ml
+++ b/src/spec/descriptor.ml
@@ -33,8 +33,7 @@ module rec Google : sig
     *)
     module rec FileDescriptorSet : sig
       type t = (FileDescriptorProto.t list)
-      type make_t = ?file:FileDescriptorProto.t list -> unit -> t
-      val make: make_t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -53,6 +52,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?file:FileDescriptorProto.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -81,8 +81,7 @@ module rec Google : sig
       syntax: string option;(** The syntax of the proto file.
        The supported values are "proto2" and "proto3". *)
       }
-      type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -101,6 +100,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -116,8 +116,7 @@ module rec Google : sig
         end': int option;(** Exclusive. *)
         options: ExtensionRangeOptions.t option;
         }
-        type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -136,6 +135,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -153,8 +153,7 @@ module rec Google : sig
         start: int option;(** Inclusive. *)
         end': int option;(** Exclusive. *)
         }
-        type make_t = ?start:int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -173,6 +172,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -192,8 +192,7 @@ module rec Google : sig
       reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
        A given name may only be reserved once. *)
       }
-      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -212,6 +211,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -223,8 +223,7 @@ module rec Google : sig
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -243,6 +242,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -370,8 +370,7 @@ module rec Google : sig
        Proto2 optional fields do not set this flag, because they already indicate
        optional with `LABEL_OPTIONAL`. *)
       }
-      type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -390,6 +389,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -403,8 +403,7 @@ module rec Google : sig
       name: string option;
       options: OneofOptions.t option;
       }
-      type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -423,6 +422,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -446,8 +446,7 @@ module rec Google : sig
         start: int option;(** Inclusive. *)
         end': int option;(** Inclusive. *)
         }
-        type make_t = ?start:int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -466,6 +465,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -482,8 +482,7 @@ module rec Google : sig
       reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
        be reserved once. *)
       }
-      type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -502,6 +501,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -516,8 +516,7 @@ module rec Google : sig
       number: int option;
       options: EnumValueOptions.t option;
       }
-      type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -536,6 +535,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -550,8 +550,7 @@ module rec Google : sig
       method': MethodDescriptorProto.t list;
       options: ServiceOptions.t option;
       }
-      type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -570,6 +569,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -588,8 +588,7 @@ module rec Google : sig
       client_streaming: bool;(** Identifies if client streams multiple client messages *)
       server_streaming: bool;(** Identifies if server streams multiple server messages *)
       }
-      type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -608,6 +607,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -713,8 +713,7 @@ module rec Google : sig
        See the documentation for the "Options" section above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -733,6 +732,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -790,8 +790,7 @@ module rec Google : sig
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -810,6 +809,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -918,8 +918,7 @@ module rec Google : sig
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -938,6 +937,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -949,8 +949,7 @@ module rec Google : sig
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -969,6 +968,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -986,8 +986,7 @@ module rec Google : sig
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1006,6 +1005,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1021,8 +1021,7 @@ module rec Google : sig
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1041,6 +1040,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1056,8 +1056,7 @@ module rec Google : sig
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1076,6 +1075,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1117,8 +1117,7 @@ module rec Google : sig
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1137,6 +1136,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1166,8 +1166,7 @@ module rec Google : sig
         name_part: string;
         is_extension: bool;
         }
-        type make_t = name_part:string -> is_extension:bool -> unit -> t
-        val make: make_t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -1186,6 +1185,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = name_part:string -> is_extension:bool -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -1202,8 +1202,7 @@ module rec Google : sig
       string_value: bytes option;
       aggregate_value: string option;
       }
-      type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
-      val make: make_t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1222,6 +1221,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1314,8 +1314,7 @@ module rec Google : sig
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
-        type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
-        val make: make_t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -1334,6 +1333,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -1387,8 +1387,7 @@ module rec Google : sig
          be recorded in the future.
       *)
 
-      type make_t = ?location:Location.t list -> unit -> t
-      val make: make_t
+      val make: ?location:Location.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1407,6 +1406,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?location:Location.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1431,8 +1431,7 @@ module rec Google : sig
          relates to the identified offset. The end offset should be one past
          the last relevant byte (so the length of the text = end - begin). *)
         }
-        type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -1451,6 +1450,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -1463,8 +1463,7 @@ module rec Google : sig
        of its generating .proto file.
       *)
 
-      type make_t = ?annotation:Annotation.t list -> unit -> t
-      val make: make_t
+      val make: ?annotation:Annotation.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1483,6 +1482,7 @@ module rec Google : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?annotation:Annotation.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1499,8 +1499,7 @@ end = struct
     *)
     module rec FileDescriptorSet : sig
       type t = (FileDescriptorProto.t list)
-      type make_t = ?file:FileDescriptorProto.t list -> unit -> t
-      val make: make_t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1519,6 +1518,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?file:FileDescriptorProto.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1547,8 +1547,7 @@ end = struct
       syntax: string option;(** The syntax of the proto file.
        The supported values are "proto2" and "proto3". *)
       }
-      type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1567,6 +1566,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1582,8 +1582,7 @@ end = struct
         end': int option;(** Exclusive. *)
         options: ExtensionRangeOptions.t option;
         }
-        type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -1602,6 +1601,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -1619,8 +1619,7 @@ end = struct
         start: int option;(** Inclusive. *)
         end': int option;(** Exclusive. *)
         }
-        type make_t = ?start:int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -1639,6 +1638,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -1658,8 +1658,7 @@ end = struct
       reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
        A given name may only be reserved once. *)
       }
-      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1678,6 +1677,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1689,8 +1689,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1709,6 +1708,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1836,8 +1836,7 @@ end = struct
        Proto2 optional fields do not set this flag, because they already indicate
        optional with `LABEL_OPTIONAL`. *)
       }
-      type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1856,6 +1855,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1869,8 +1869,7 @@ end = struct
       name: string option;
       options: OneofOptions.t option;
       }
-      type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1889,6 +1888,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1912,8 +1912,7 @@ end = struct
         start: int option;(** Inclusive. *)
         end': int option;(** Inclusive. *)
         }
-        type make_t = ?start:int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -1932,6 +1931,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -1948,8 +1948,7 @@ end = struct
       reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
        be reserved once. *)
       }
-      type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -1968,6 +1967,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1982,8 +1982,7 @@ end = struct
       number: int option;
       options: EnumValueOptions.t option;
       }
-      type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2002,6 +2001,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2016,8 +2016,7 @@ end = struct
       method': MethodDescriptorProto.t list;
       options: ServiceOptions.t option;
       }
-      type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2036,6 +2035,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2054,8 +2054,7 @@ end = struct
       client_streaming: bool;(** Identifies if client streams multiple client messages *)
       server_streaming: bool;(** Identifies if server streams multiple server messages *)
       }
-      type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2074,6 +2073,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2179,8 +2179,7 @@ end = struct
        See the documentation for the "Options" section above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2199,6 +2198,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2256,8 +2256,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2276,6 +2275,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2384,8 +2384,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2404,6 +2403,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2415,8 +2415,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2435,6 +2434,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2452,8 +2452,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2472,6 +2471,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2487,8 +2487,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2507,6 +2506,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2522,8 +2522,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2542,6 +2541,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2583,8 +2583,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2603,6 +2602,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2632,8 +2632,7 @@ end = struct
         name_part: string;
         is_extension: bool;
         }
-        type make_t = name_part:string -> is_extension:bool -> unit -> t
-        val make: make_t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -2652,6 +2651,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = name_part:string -> is_extension:bool -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -2668,8 +2668,7 @@ end = struct
       string_value: bytes option;
       aggregate_value: string option;
       }
-      type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
-      val make: make_t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2688,6 +2687,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2780,8 +2780,7 @@ end = struct
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
-        type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
-        val make: make_t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -2800,6 +2799,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -2853,8 +2853,7 @@ end = struct
          be recorded in the future.
       *)
 
-      type make_t = ?location:Location.t list -> unit -> t
-      val make: make_t
+      val make: ?location:Location.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2873,6 +2872,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?location:Location.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2897,8 +2897,7 @@ end = struct
          relates to the identified offset. The end offset should be one past
          the last relevant byte (so the length of the text = end - begin). *)
         }
-        type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -2917,6 +2916,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -2929,8 +2929,7 @@ end = struct
        of its generating .proto file.
       *)
 
-      type make_t = ?annotation:Annotation.t list -> unit -> t
-      val make: make_t
+      val make: ?annotation:Annotation.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2949,6 +2948,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?annotation:Annotation.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -2958,8 +2958,7 @@ end = struct
   end = struct
     module rec FileDescriptorSet : sig
       type t = (FileDescriptorProto.t list)
-      type make_t = ?file:FileDescriptorProto.t list -> unit -> t
-      val make: make_t
+      val make: ?file:FileDescriptorProto.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2978,6 +2977,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?file:FileDescriptorProto.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -3030,8 +3030,7 @@ end = struct
       syntax: string option;(** The syntax of the proto file.
        The supported values are "proto2" and "proto3". *)
       }
-      type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -3050,6 +3049,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -3131,8 +3131,7 @@ end = struct
         end': int option;(** Exclusive. *)
         options: ExtensionRangeOptions.t option;
         }
-        type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -3151,6 +3150,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -3168,8 +3168,7 @@ end = struct
         start: int option;(** Inclusive. *)
         end': int option;(** Exclusive. *)
         }
-        type make_t = ?start:int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -3188,6 +3187,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -3207,8 +3207,7 @@ end = struct
       reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
        A given name may only be reserved once. *)
       }
-      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -3227,6 +3226,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -3240,8 +3240,7 @@ end = struct
         end': int option;(** Exclusive. *)
         options: ExtensionRangeOptions.t option;
         }
-        type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -3260,6 +3259,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -3307,8 +3307,7 @@ end = struct
         start: int option;(** Inclusive. *)
         end': int option;(** Exclusive. *)
         }
-        type make_t = ?start:int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -3327,6 +3326,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -3428,8 +3428,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -3448,6 +3447,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -3605,8 +3605,7 @@ end = struct
        Proto2 optional fields do not set this flag, because they already indicate
        optional with `LABEL_OPTIONAL`. *)
       }
-      type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -3625,6 +3624,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -3955,8 +3955,7 @@ end = struct
       name: string option;
       options: OneofOptions.t option;
       }
-      type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?options:OneofOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -3975,6 +3974,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -4029,8 +4029,7 @@ end = struct
         start: int option;(** Inclusive. *)
         end': int option;(** Inclusive. *)
         }
-        type make_t = ?start:int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -4049,6 +4048,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -4065,8 +4065,7 @@ end = struct
       reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
        be reserved once. *)
       }
-      type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -4085,6 +4084,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -4097,8 +4097,7 @@ end = struct
         start: int option;(** Inclusive. *)
         end': int option;(** Inclusive. *)
         }
-        type make_t = ?start:int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?start:int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -4117,6 +4116,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?start:int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -4206,8 +4206,7 @@ end = struct
       number: int option;
       options: EnumValueOptions.t option;
       }
-      type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -4226,6 +4225,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -4274,8 +4274,7 @@ end = struct
       method': MethodDescriptorProto.t list;
       options: ServiceOptions.t option;
       }
-      type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -4294,6 +4293,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -4346,8 +4346,7 @@ end = struct
       client_streaming: bool;(** Identifies if client streams multiple client messages *)
       server_streaming: bool;(** Identifies if server streams multiple server messages *)
       }
-      type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
-      val make: make_t
+      val make: ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -4366,6 +4365,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -4517,8 +4517,7 @@ end = struct
        See the documentation for the "Options" section above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -4537,6 +4536,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -4793,8 +4793,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -4813,6 +4812,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -5007,8 +5007,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -5027,6 +5026,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -5241,8 +5241,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -5261,6 +5260,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -5310,8 +5310,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -5330,6 +5329,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -5387,8 +5387,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -5407,6 +5406,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -5460,8 +5460,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -5480,6 +5479,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -5559,8 +5559,7 @@ end = struct
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
-      type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
-      val make: make_t
+      val make: ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -5579,6 +5578,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -5689,8 +5689,7 @@ end = struct
         name_part: string;
         is_extension: bool;
         }
-        type make_t = name_part:string -> is_extension:bool -> unit -> t
-        val make: make_t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -5709,6 +5708,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = name_part:string -> is_extension:bool -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -5725,8 +5725,7 @@ end = struct
       string_value: bytes option;
       aggregate_value: string option;
       }
-      type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
-      val make: make_t
+      val make: ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -5745,6 +5744,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -5757,8 +5757,7 @@ end = struct
         name_part: string;
         is_extension: bool;
         }
-        type make_t = name_part:string -> is_extension:bool -> unit -> t
-        val make: make_t
+        val make: name_part:string -> is_extension:bool -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -5777,6 +5776,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = name_part:string -> is_extension:bool -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -5945,8 +5945,7 @@ end = struct
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
-        type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
-        val make: make_t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -5965,6 +5964,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -6018,8 +6018,7 @@ end = struct
          be recorded in the future.
       *)
 
-      type make_t = ?location:Location.t list -> unit -> t
-      val make: make_t
+      val make: ?location:Location.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -6038,6 +6037,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?location:Location.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -6125,8 +6125,7 @@ end = struct
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
-        type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
-        val make: make_t
+        val make: ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -6145,6 +6144,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -6348,8 +6348,7 @@ end = struct
          relates to the identified offset. The end offset should be one past
          the last relevant byte (so the length of the text = end - begin). *)
         }
-        type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -6368,6 +6367,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -6380,8 +6380,7 @@ end = struct
        of its generating .proto file.
       *)
 
-      type make_t = ?annotation:Annotation.t list -> unit -> t
-      val make: make_t
+      val make: ?annotation:Annotation.t list -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -6400,6 +6399,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
+      type make_t = ?annotation:Annotation.t list -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -6418,8 +6418,7 @@ end = struct
          relates to the identified offset. The end offset should be one past
          the last relevant byte (so the length of the text = end - begin). *)
         }
-        type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
-        val make: make_t
+        val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -6438,6 +6437,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t

--- a/src/spec/descriptor.ml
+++ b/src/spec/descriptor.ml
@@ -32,894 +32,2966 @@ module rec Google : sig
        files it parses.
     *)
     module rec FileDescriptorSet : sig
-      val name: unit -> string
       type t = (FileDescriptorProto.t list)
       type make_t = ?file:FileDescriptorProto.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a complete .proto file. *)
     and FileDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
+      type t = {
+      name: string option;(** file name, relative to root of source tree *)
+      package: string option;(** e.g. "foo", "foo.bar", etc. *)
+      dependency: string list;(** Names of files imported by this file. *)
+      message_type: DescriptorProto.t list;(** All top-level definitions in this file. *)
+      enum_type: EnumDescriptorProto.t list;
+      service: ServiceDescriptorProto.t list;
+      extension: FieldDescriptorProto.t list;
+      options: FileOptions.t option;
+      source_code_info: SourceCodeInfo.t option;(** This field contains optional information about the original source code.
+       You may safely remove this entire field without harming runtime
+       functionality of the descriptors -- the information is needed only by
+       development tools. *)
+      public_dependency: int list;(** Indexes of the public imported files in the dependency list above. *)
+      weak_dependency: int list;(** Indexes of the weak imported files in the dependency list.
+       For Google-internal migration only. Do not use. *)
+      syntax: string option;(** The syntax of the proto file.
+       The supported values are "proto2" and "proto3". *)
+      }
       type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a message type. *)
     and DescriptorProto : sig
       module rec ExtensionRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        options: ExtensionRangeOptions.t option;
+        }
         type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (**
+         Range of reserved tag numbers. Reserved tag numbers may not be used by
+         fields or extension ranges in the same message. Reserved ranges may
+         not overlap.
+      *)
       and ReservedRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      type t = {
+      name: string option;
+      field: FieldDescriptorProto.t list;
+      nested_type: t list;
+      enum_type: EnumDescriptorProto.t list;
+      extension_range: ExtensionRange.t list;
+      extension: FieldDescriptorProto.t list;
+      options: MessageOptions.t option;
+      oneof_decl: OneofDescriptorProto.t list;
+      reserved_range: ReservedRange.t list;
+      reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
+       A given name may only be reserved once. *)
+      }
+      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and ExtensionRangeOptions : sig
-      val name: unit -> string
-      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a field within a message. *)
     and FieldDescriptorProto : sig
       module rec Type : sig
-        type t = TYPE_DOUBLE | TYPE_FLOAT | TYPE_INT64 | TYPE_UINT64 | TYPE_INT32 | TYPE_FIXED64 | TYPE_FIXED32 | TYPE_BOOL | TYPE_STRING | TYPE_GROUP | TYPE_MESSAGE | TYPE_BYTES | TYPE_UINT32 | TYPE_ENUM | TYPE_SFIXED32 | TYPE_SFIXED64 | TYPE_SINT32 | TYPE_SINT64
+        type t =
+          | TYPE_DOUBLE
+          (**
+             0 is reserved for errors.
+             Order is weird for historical reasons.
+          *)
+          | TYPE_FLOAT
+          | TYPE_INT64
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+             negative values are likely.
+          *)
+          | TYPE_UINT64
+          | TYPE_INT32
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+             negative values are likely.
+          *)
+          | TYPE_FIXED64
+          | TYPE_FIXED32
+          | TYPE_BOOL
+          | TYPE_STRING
+          | TYPE_GROUP
+          (**
+             Tag-delimited aggregate.
+             Group type is deprecated and not supported in proto3. However, Proto3
+             implementations should still be able to parse the group wire format and
+             treat group fields as unknown fields.
+          *)
+          | TYPE_MESSAGE
+          (** Length-delimited aggregate. *)
+          | TYPE_BYTES
+          (** New in version 2. *)
+          | TYPE_UINT32
+          | TYPE_ENUM
+          | TYPE_SFIXED32
+          | TYPE_SFIXED64
+          | TYPE_SINT32
+          (** Uses ZigZag encoding. *)
+          | TYPE_SINT64
+          (** Uses ZigZag encoding. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
       and Label : sig
-        type t = LABEL_OPTIONAL | LABEL_REQUIRED | LABEL_REPEATED
+        type t =
+          | LABEL_OPTIONAL
+          (** 0 is reserved for errors *)
+          | LABEL_REQUIRED
+          | LABEL_REPEATED
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
+      type t = {
+      name: string option;
+      extendee: string option;(** For extensions, this is the name of the type being extended.  It is
+       resolved in the same manner as type_name. *)
+      number: int option;
+      label: Label.t option;
+      type': Type.t option;(** If type_name is set, this need not be set.  If both this and type_name
+       are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
+      type_name: string option;(** For message and enum types, this is the name of the type.  If the name
+       starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+       rules are used to find the type (i.e. first the nested types within this
+       message are searched, then within the parent, on up to the root
+       namespace). *)
+      default_value: string option;(** For numeric types, contains the original text representation of the value.
+       For booleans, "true" or "false".
+       For strings, contains the default text contents (not escaped in any way).
+       For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
+      options: FieldOptions.t option;
+      oneof_index: int option;(** If set, gives the index of a oneof in the containing type's oneof_decl
+       list.  This field is a member of that oneof. *)
+      json_name: string option;(** JSON name of this field. The value is set by protocol compiler. If the
+       user has set a "json_name" option on this field, that option's value
+       will be used. Otherwise, it's deduced from the field's name by converting
+       it to camelCase. *)
+      proto3_optional: bool option;(** If true, this is a proto3 "optional". When a proto3 field is optional, it
+       tracks presence regardless of field type.
+
+       When proto3_optional is true, this field must be belong to a oneof to
+       signal to old proto3 clients that presence is tracked for this field. This
+       oneof is known as a "synthetic" oneof, and this field must be its sole
+       member (each proto3 optional field gets its own synthetic oneof). Synthetic
+       oneofs exist in the descriptor only, and do not generate any API. Synthetic
+       oneofs must be ordered after all "real" oneofs.
+
+       For message fields, proto3_optional doesn't create any semantic change,
+       since non-repeated message fields always track presence. However it still
+       indicates the semantic detail of whether the user wrote "optional" or not.
+       This can be useful for round-tripping the .proto file. For consistency we
+       give message fields a synthetic oneof also, even though it is not required
+       to track presence. This is especially important because the parser can't
+       tell if a field is a message or an enum, so it must always create a
+       synthetic oneof.
+
+       Proto2 optional fields do not set this flag, because they already indicate
+       optional with `LABEL_OPTIONAL`. *)
+      }
       type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a oneof. *)
     and OneofDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; options: OneofOptions.t option }
+      type t = {
+      name: string option;
+      options: OneofOptions.t option;
+      }
       type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes an enum type. *)
     and EnumDescriptorProto : sig
+
+      (**
+         Range of reserved numeric values. Reserved values may not be used by
+         entries in the same enum. Reserved ranges may not overlap.
+
+         Note that this is distinct from DescriptorProto.ReservedRange in that it
+         is inclusive such that it can appropriately represent the entire int32
+         domain.
+      *)
       module rec EnumReservedRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Inclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
+      type t = {
+      name: string option;
+      value: EnumValueDescriptorProto.t list;
+      options: EnumOptions.t option;
+      reserved_range: EnumReservedRange.t list;(** Range of reserved numeric values. Reserved numeric values may not be used
+       by enum values in the same enum declaration. Reserved ranges may not
+       overlap. *)
+      reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
+       be reserved once. *)
+      }
       type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a value within an enum. *)
     and EnumValueDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; number: int option; options: EnumValueOptions.t option }
+      type t = {
+      name: string option;
+      number: int option;
+      options: EnumValueOptions.t option;
+      }
       type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a service. *)
     and ServiceDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
+      type t = {
+      name: string option;
+      method': MethodDescriptorProto.t list;
+      options: ServiceOptions.t option;
+      }
       type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a method of a service. *)
     and MethodDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
+      type t = {
+      name: string option;
+      input_type: string option;(** Input and output type names.  These are resolved in the same way as
+       FieldDescriptorProto.type_name, but must refer to a message type. *)
+      output_type: string option;
+      options: MethodOptions.t option;
+      client_streaming: bool;(** Identifies if client streams multiple client messages *)
+      server_streaming: bool;(** Identifies if server streams multiple server messages *)
+      }
       type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and FileOptions : sig
+
+      (** Generated classes can be optimized for speed or code size. *)
       module rec OptimizeMode : sig
-        type t = SPEED | CODE_SIZE | LITE_RUNTIME
+        type t =
+          | SPEED
+          (** Generate complete code for parsing, serialization, *)
+          | CODE_SIZE
+          (**
+             etc.
+
+             Use ReflectionOps to implement these methods.
+          *)
+          | LITE_RUNTIME
+          (** Generate code using MessageLite and the lite runtime. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"]; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      java_package: string option;(** Sets the Java package where classes generated from this .proto will be
+       placed.  By default, the proto package is used, but this is often
+       inappropriate because proto packages do not normally start with backwards
+       domain names. *)
+      java_outer_classname: string option;(** Controls the name of the wrapper Java class generated for the .proto file.
+       That class will always contain the .proto file's getDescriptor() method as
+       well as any top-level extensions defined in the .proto file.
+       If java_multiple_files is disabled, then all the other classes from the
+       .proto file will be nested inside the single wrapper outer class. *)
+      optimize_for: OptimizeMode.t;(** Clients can define custom options in extensions of this message.
+       See the documentation for the "Options" section above. *)
+      java_multiple_files: bool;(** If enabled, then the Java code generator will generate a separate .java
+       file for each top-level message, enum, and service defined in the .proto
+       file.  Thus, these types will *not* be nested inside the wrapper class
+       named by java_outer_classname.  However, the wrapper class will still be
+       generated to contain the file's getDescriptor() method as well as any
+       top-level extensions defined in the file. *)
+      go_package: string option;(** Sets the Go package where structs generated from this .proto will be
+       placed. If omitted, the Go package will be derived from the following:
+         - The basename of the package import path, if provided.
+         - Otherwise, the package statement in the .proto file, if present.
+         - Otherwise, the basename of the .proto file, without extension. *)
+      cc_generic_services: bool;(** Should generic services be generated in each language?  "Generic" services
+       are not specific to any particular RPC system.  They are generated by the
+       main code generators in each language (without additional plugins).
+       Generic services were the only kind of service generation supported by
+       early versions of google.protobuf.
+
+       Generic services are now considered deprecated in favor of using plugins
+       that generate code specific to your particular RPC system.  Therefore,
+       these default to false.  Old code which depends on generic services should
+       explicitly set them to true. *)
+      java_generic_services: bool;
+      py_generic_services: bool;
+      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"];(** This option does nothing.
+      @deprecated deprecated in proto file *)
+      deprecated: bool;(** Is this file deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for everything in the file, or it will be completely ignored; in the very
+       least, this is a formalization for deprecating files. *)
+      java_string_check_utf8: bool;(** If set true, then the Java2 code generator will generate code that
+       throws an exception whenever an attempt is made to assign a non-UTF-8
+       byte sequence to a string field.
+       Message reflection will do the same.
+       However, an extension field still accepts non-UTF-8 byte sequences.
+       This option has no effect on when used with the lite runtime. *)
+      cc_enable_arenas: bool;(** Enables the use of arenas for the proto messages in this file. This applies
+       only to generated classes for C++. *)
+      objc_class_prefix: string option;(** Sets the objective c class prefix which is prepended to all objective c
+       generated classes from this .proto. There is no default. *)
+      csharp_namespace: string option;(** Namespace for generated classes; defaults to the package. *)
+      swift_prefix: string option;(** By default Swift generators will take the proto package and CamelCase it
+       replacing '.' with underscore and use that to prefix the types/symbols
+       defined. When this options is provided, they will use this value instead
+       to prefix the types/symbols defined. *)
+      php_class_prefix: string option;(** Sets the php class prefix which is prepended to all php generated classes
+       from this .proto. Default is empty. *)
+      php_namespace: string option;(** Use this option to change the namespace of php generated classes. Default
+       is empty. When this option is empty, the package name will be used for
+       determining the namespace. *)
+      php_generic_services: bool;
+      php_metadata_namespace: string option;(** Use this option to change the namespace of php generated metadata classes.
+       Default is empty. When this option is empty, the proto file name will be
+       used for determining the namespace. *)
+      ruby_package: string option;(** Use this option to change the package of ruby generated classes. Default
+       is empty. When this option is not set, the package name will be used for
+       determining the ruby package. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here.
+       See the documentation for the "Options" section above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and MessageOptions : sig
-      val name: unit -> string
-      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      message_set_wire_format: bool;(** Set true to use the old proto1 MessageSet wire format for extensions.
+       This is provided for backwards-compatibility with the MessageSet wire
+       format.  You should not use this for any other reason:  It's less
+       efficient, has fewer features, and is more complicated.
+
+       The message must be defined exactly as follows:
+         message Foo \{
+           option message_set_wire_format = true;
+           extensions 4 to max;
+         \}
+       Note that the message cannot have any defined fields; MessageSets only
+       have extensions.
+
+       All extensions of your type must be singular messages; e.g. they cannot
+       be int32s, enums, or repeated messages.
+
+       Because this is an option, the above two restrictions are not enforced by
+       the protocol compiler. *)
+      no_standard_descriptor_accessor: bool;(** Disables the generation of the standard "descriptor()" accessor, which can
+       conflict with a field of the same name.  This is meant to make migration
+       from proto1 easier; new code should avoid fields named "descriptor". *)
+      deprecated: bool;(** Is this message deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the message, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating messages. *)
+      map_entry: bool option;(** Whether the message is an automatically generated map entry type for the
+       maps field.
+
+       For maps fields:
+           map<KeyType, ValueType> map_field = 1;
+       The parsed descriptor looks like:
+           message MapFieldEntry \{
+               option map_entry = true;
+               optional KeyType key = 1;
+               optional ValueType value = 2;
+           \}
+           repeated MapFieldEntry map_field = 1;
+
+       Implementations may choose not to generate the map_entry=true message, but
+       use a native map in the target language to hold the keys and values.
+       The reflection APIs in such implementations still need to work as
+       if the field is a repeated message field.
+
+       NOTE: Do not set the option in .proto files. Always use the maps syntax
+       instead. The option should only be implicitly set by the proto compiler
+       parser. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and FieldOptions : sig
       module rec CType : sig
-        type t = STRING | CORD | STRING_PIECE
+        type t =
+          | STRING
+          (** Default mode. *)
+          | CORD
+          | STRING_PIECE
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
       and JSType : sig
-        type t = JS_NORMAL | JS_STRING | JS_NUMBER
+        type t =
+          | JS_NORMAL
+          (** Use the default type. *)
+          | JS_STRING
+          (** Use JavaScript strings. *)
+          | JS_NUMBER
+          (** Use JavaScript numbers. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      ctype: CType.t;(** The ctype option instructs the C++ code generator to use a different
+       representation of the field than it normally would.  See the specific
+       options below.  This option is not yet implemented in the open source
+       release -- sorry, we'll try to include it in a future version! *)
+      packed: bool option;(** The packed option can be enabled for repeated primitive fields to enable
+       a more efficient representation on the wire. Rather than repeatedly
+       writing the tag and type for each element, the entire array is encoded as
+       a single length-delimited blob. In proto3, only explicit setting it to
+       false will avoid using packed encoding. *)
+      deprecated: bool;(** Clients can define custom options in extensions of this message. See above. *)
+      lazy': bool;(** Should this field be parsed lazily?  Lazy applies only to message-type
+       fields.  It means that when the outer message is initially parsed, the
+       inner message's contents will not be parsed but instead stored in encoded
+       form.  The inner message will actually be parsed when it is first accessed.
+
+       This is only a hint.  Implementations are free to choose whether to use
+       eager or lazy parsing regardless of the value of this option.  However,
+       setting this option true suggests that the protocol author believes that
+       using lazy parsing on this field is worth the additional bookkeeping
+       overhead typically needed to implement it.
+
+       This option does not affect the public interface of any generated code;
+       all method signatures remain the same.  Furthermore, thread-safety of the
+       interface is not affected by this option; const methods remain safe to
+       call from multiple threads concurrently, while non-const methods continue
+       to require exclusive access.
+
+
+       Note that implementations may choose not to check required fields within
+       a lazy sub-message.  That is, calling IsInitialized() on the outer message
+       may return true even if the inner message has missing required fields.
+       This is necessary because otherwise the inner message would have to be
+       parsed in order to perform the check, defeating the purpose of lazy
+       parsing.  An implementation which chooses not to check required fields
+       must be consistent about it.  That is, for any particular sub-message, the
+       implementation must either *always* check its required fields, or *never*
+       check its required fields, regardless of whether or not the message has
+       been parsed.
+
+       As of 2021, lazy does no correctness checks on the byte stream during
+       parsing.  This may lead to crashes if and when an invalid byte stream is
+       finally parsed upon access.
+
+       TODO(b/211906113):  Enable validation on lazy fields. *)
+      jstype: JSType.t;(** The jstype option determines the JavaScript type used for values of the
+       field.  The option is permitted only for 64 bit integral and fixed types
+       (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+       is represented as JavaScript string, which avoids loss of precision that
+       can happen when a large value is converted to a floating point JavaScript.
+       Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+       use the JavaScript "number" type.  The behavior of the default option
+       JS_NORMAL is implementation dependent.
+
+       This option is an enum to permit additional types to be added, e.g.
+       goog.math.Integer. *)
+      weak: bool;(** For Google-internal migration only. Do not use. *)
+      unverified_lazy: bool;(** unverified_lazy does no correctness checks on the byte stream. This should
+       only be used where lazy with verification is prohibitive for performance
+       reasons. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and OneofOptions : sig
-      val name: unit -> string
-      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and EnumOptions : sig
-      val name: unit -> string
-      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      allow_alias: bool option;(** Set this option to true to allow mapping different tag names to the same
+       value. *)
+      deprecated: bool;(** Is this enum deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the enum, or it will be completely ignored; in the very least, this
+       is a formalization for deprecating enums. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and EnumValueOptions : sig
-      val name: unit -> string
-      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this enum value deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the enum value, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating enum values. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and ServiceOptions : sig
-      val name: unit -> string
-      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this service deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the service, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating services. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and MethodOptions : sig
+
+      (**
+         Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+         or neither? HTTP based RPC implementation may choose GET verb for safe
+         methods, and PUT verb for idempotent methods instead of the default POST.
+      *)
       module rec IdempotencyLevel : sig
-        type t = IDEMPOTENCY_UNKNOWN | NO_SIDE_EFFECTS | IDEMPOTENT
+        type t =
+          | IDEMPOTENCY_UNKNOWN
+          | NO_SIDE_EFFECTS
+          (** implies idempotent *)
+          | IDEMPOTENT
+          (** idempotent, but may have side effects *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this method deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the method, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating methods. *)
+      idempotency_level: IdempotencyLevel.t;
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (**
+       A message representing a option the parser does not recognize. This only
+       appears in options protos created by the compiler::Parser class.
+       DescriptorPool resolves these when building Descriptor objects. Therefore,
+       options protos in descriptor objects (e.g. returned by Descriptor::options(),
+       or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+       in them.
+    *)
     and UninterpretedOption : sig
+
+      (**
+         The name of the uninterpreted option.  Each string represents a segment in
+         a dot-separated name.  is_extension is true iff a segment represents an
+         extension (denoted with parentheses in options specs in .proto files).
+         E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
+         "foo.(bar.baz).moo".
+      *)
       module rec NamePart : sig
-        val name: unit -> string
-        type t = { name_part: string; is_extension: bool }
+        type t = {
+        name_part: string;
+        is_extension: bool;
+        }
         type make_t = name_part:string -> is_extension:bool -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
+      type t = {
+      name: NamePart.t list;
+      identifier_value: string option;(** The value of the uninterpreted option, in whatever type the tokenizer
+       identified it as during parsing. Exactly one of these should be set. *)
+      positive_int_value: int option;
+      negative_int_value: int option;
+      double_value: float option;
+      string_value: bytes option;
+      aggregate_value: string option;
+      }
       type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (**
+       Encapsulates information about the original source file from which a
+       FileDescriptorProto was generated.
+    *)
     and SourceCodeInfo : sig
       module rec Location : sig
-        val name: unit -> string
-        type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
+        type t = {
+        path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
+         location.
+
+         Each element is a field number or an index.  They form a path from
+         the root FileDescriptorProto to the place where the definition occurs.
+         For example, this path:
+           \[ 4, 3, 2, 7, 1 \]
+         refers to:
+           file.message_type(3)  // 4, 3
+               .field(7)         // 2, 7
+               .name()           // 1
+         This is because FileDescriptorProto.message_type has field number 4:
+           repeated DescriptorProto message_type = 4;
+         and DescriptorProto.field has field number 2:
+           repeated FieldDescriptorProto field = 2;
+         and FieldDescriptorProto.name has field number 1:
+           optional string name = 1;
+
+         Thus, the above path gives the location of a field name.  If we removed
+         the last element:
+           \[ 4, 3, 2, 7 \]
+         this path refers to the whole field declaration (from the beginning
+         of the label to the terminating semicolon). *)
+        span: int list;(** Always has exactly three or four elements: start line, start column,
+         end line (optional, otherwise assumed same as start line), end column.
+         These are packed into a single field for efficiency.  Note that line
+         and column numbers are zero-based -- typically you will want to add
+         1 to each before displaying to a user. *)
+        leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
+         comments appearing before and after the declaration which appear to be
+         attached to the declaration.
+
+         A series of line comments appearing on consecutive lines, with no other
+         tokens appearing on those lines, will be treated as a single comment.
+
+         leading_detached_comments will keep paragraphs of comments that appear
+         before (but not connected to) the current element. Each paragraph,
+         separated by empty lines, will be one comment element in the repeated
+         field.
+
+         Only the comment content is provided; comment markers (e.g. //) are
+         stripped out.  For block comments, leading whitespace and an asterisk
+         will be stripped from the beginning of each line other than the first.
+         Newlines are included in the output.
+
+         Examples:
+
+           optional int32 foo = 1;  // Comment attached to foo.
+           // Comment attached to bar.
+           optional int32 bar = 2;
+
+           optional string baz = 3;
+           // Comment attached to baz.
+           // Another line attached to baz.
+
+           // Comment attached to moo.
+           //
+           // Another line attached to moo.
+           optional double moo = 4;
+
+           // Detached comment for corge. This is not leading or trailing comments
+           // to moo or corge because there are blank lines separating it from
+           // both.
+
+           // Detached comment for corge paragraph 2.
+
+           optional string corge = 5;
+           /* Block comment attached
+            * to corge.  Leading asterisks
+            * will be removed. */
+           /* Block comment attached to
+            * grault. */
+           optional int32 grault = 6;
+
+           // ignored detached comments. *)
+        trailing_comments: string option;
+        leading_detached_comments: string list;
+        }
         type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
       type t = (Location.t list)
+      (**
+      @param location A Location identifies a piece of source code in a .proto file which
+       corresponds to a particular definition.  This information is intended
+       to be useful to IDEs, code indexers, documentation generators, and similar
+       tools.
+
+       For example, say we have a file like:
+         message Foo \{
+           optional string foo = 1;
+         \}
+       Let's look at just the field definition:
+         optional string foo = 1;
+         ^       ^^     ^^  ^  ^^^
+         a       bc     de  f  ghi
+       We have the following locations:
+         span   path               represents
+         \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
+         \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
+         \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
+         \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
+         \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
+
+       Notes:
+       - A location may refer to a repeated field itself (i.e. not to any
+         particular index within it).  This is used whenever a set of elements are
+         logically enclosed in a single code segment.  For example, an entire
+         extend block (possibly containing multiple extension definitions) will
+         have an outer location whose path refers to the "extensions" repeated
+         field without an index.
+       - Multiple locations may have the same path.  This happens when a single
+         logical declaration is spread out across multiple places.  The most
+         obvious example is the "extend" block again -- there may be multiple
+         extend blocks in the same scope, each of which will have the same path.
+       - A location's span is not always a subset of its parent's span.  For
+         example, the "extendee" of an extension declaration appears at the
+         beginning of the "extend" block and is shared by all extensions within
+         the block.
+       - Just because a location's span is a subset of some other location's span
+         does not mean that it is a descendant.  For example, a "group" defines
+         both a type and a field in a single declaration.  Thus, the locations
+         corresponding to the type and field and their components will overlap.
+       - Code which tries to interpret locations should probably be designed to
+         ignore those that it doesn't understand, as more types of locations could
+         be recorded in the future.
+      *)
+
       type make_t = ?location:Location.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (**
+       Describes the relationship between generated code and its original source
+       file. A GeneratedCodeInfo message is associated with only one generated
+       source file, but may contain references to different source .proto files.
+    *)
     and GeneratedCodeInfo : sig
       module rec Annotation : sig
-        val name: unit -> string
-        type t = { path: int list; source_file: string option; begin': int option; end': int option }
+        type t = {
+        path: int list;(** Identifies the element in the original source .proto file. This field
+         is formatted the same as SourceCodeInfo.Location.path. *)
+        source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
+        begin': int option;(** Identifies the starting offset in bytes in the generated code
+         that relates to the identified object. *)
+        end': int option;(** Identifies the ending offset in bytes in the generated code that
+         relates to the identified offset. The end offset should be one past
+         the last relevant byte (so the length of the text = end - begin). *)
+        }
         type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
       type t = (Annotation.t list)
+      (**
+      @param annotation An Annotation connects some span of text in generated code to an element
+       of its generating .proto file.
+      *)
+
       type make_t = ?annotation:Annotation.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
   end
 end = struct
   module rec Protobuf : sig
+
+    (**
+       The protocol compiler can output a FileDescriptorSet containing the .proto
+       files it parses.
+    *)
     module rec FileDescriptorSet : sig
-      val name: unit -> string
       type t = (FileDescriptorProto.t list)
       type make_t = ?file:FileDescriptorProto.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a complete .proto file. *)
     and FileDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
+      type t = {
+      name: string option;(** file name, relative to root of source tree *)
+      package: string option;(** e.g. "foo", "foo.bar", etc. *)
+      dependency: string list;(** Names of files imported by this file. *)
+      message_type: DescriptorProto.t list;(** All top-level definitions in this file. *)
+      enum_type: EnumDescriptorProto.t list;
+      service: ServiceDescriptorProto.t list;
+      extension: FieldDescriptorProto.t list;
+      options: FileOptions.t option;
+      source_code_info: SourceCodeInfo.t option;(** This field contains optional information about the original source code.
+       You may safely remove this entire field without harming runtime
+       functionality of the descriptors -- the information is needed only by
+       development tools. *)
+      public_dependency: int list;(** Indexes of the public imported files in the dependency list above. *)
+      weak_dependency: int list;(** Indexes of the weak imported files in the dependency list.
+       For Google-internal migration only. Do not use. *)
+      syntax: string option;(** The syntax of the proto file.
+       The supported values are "proto2" and "proto3". *)
+      }
       type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a message type. *)
     and DescriptorProto : sig
       module rec ExtensionRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        options: ExtensionRangeOptions.t option;
+        }
         type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (**
+         Range of reserved tag numbers. Reserved tag numbers may not be used by
+         fields or extension ranges in the same message. Reserved ranges may
+         not overlap.
+      *)
       and ReservedRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      type t = {
+      name: string option;
+      field: FieldDescriptorProto.t list;
+      nested_type: t list;
+      enum_type: EnumDescriptorProto.t list;
+      extension_range: ExtensionRange.t list;
+      extension: FieldDescriptorProto.t list;
+      options: MessageOptions.t option;
+      oneof_decl: OneofDescriptorProto.t list;
+      reserved_range: ReservedRange.t list;
+      reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
+       A given name may only be reserved once. *)
+      }
+      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and ExtensionRangeOptions : sig
-      val name: unit -> string
-      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a field within a message. *)
     and FieldDescriptorProto : sig
       module rec Type : sig
-        type t = TYPE_DOUBLE | TYPE_FLOAT | TYPE_INT64 | TYPE_UINT64 | TYPE_INT32 | TYPE_FIXED64 | TYPE_FIXED32 | TYPE_BOOL | TYPE_STRING | TYPE_GROUP | TYPE_MESSAGE | TYPE_BYTES | TYPE_UINT32 | TYPE_ENUM | TYPE_SFIXED32 | TYPE_SFIXED64 | TYPE_SINT32 | TYPE_SINT64
+        type t =
+          | TYPE_DOUBLE
+          (**
+             0 is reserved for errors.
+             Order is weird for historical reasons.
+          *)
+          | TYPE_FLOAT
+          | TYPE_INT64
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+             negative values are likely.
+          *)
+          | TYPE_UINT64
+          | TYPE_INT32
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+             negative values are likely.
+          *)
+          | TYPE_FIXED64
+          | TYPE_FIXED32
+          | TYPE_BOOL
+          | TYPE_STRING
+          | TYPE_GROUP
+          (**
+             Tag-delimited aggregate.
+             Group type is deprecated and not supported in proto3. However, Proto3
+             implementations should still be able to parse the group wire format and
+             treat group fields as unknown fields.
+          *)
+          | TYPE_MESSAGE
+          (** Length-delimited aggregate. *)
+          | TYPE_BYTES
+          (** New in version 2. *)
+          | TYPE_UINT32
+          | TYPE_ENUM
+          | TYPE_SFIXED32
+          | TYPE_SFIXED64
+          | TYPE_SINT32
+          (** Uses ZigZag encoding. *)
+          | TYPE_SINT64
+          (** Uses ZigZag encoding. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
       and Label : sig
-        type t = LABEL_OPTIONAL | LABEL_REQUIRED | LABEL_REPEATED
+        type t =
+          | LABEL_OPTIONAL
+          (** 0 is reserved for errors *)
+          | LABEL_REQUIRED
+          | LABEL_REPEATED
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
+      type t = {
+      name: string option;
+      extendee: string option;(** For extensions, this is the name of the type being extended.  It is
+       resolved in the same manner as type_name. *)
+      number: int option;
+      label: Label.t option;
+      type': Type.t option;(** If type_name is set, this need not be set.  If both this and type_name
+       are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
+      type_name: string option;(** For message and enum types, this is the name of the type.  If the name
+       starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+       rules are used to find the type (i.e. first the nested types within this
+       message are searched, then within the parent, on up to the root
+       namespace). *)
+      default_value: string option;(** For numeric types, contains the original text representation of the value.
+       For booleans, "true" or "false".
+       For strings, contains the default text contents (not escaped in any way).
+       For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
+      options: FieldOptions.t option;
+      oneof_index: int option;(** If set, gives the index of a oneof in the containing type's oneof_decl
+       list.  This field is a member of that oneof. *)
+      json_name: string option;(** JSON name of this field. The value is set by protocol compiler. If the
+       user has set a "json_name" option on this field, that option's value
+       will be used. Otherwise, it's deduced from the field's name by converting
+       it to camelCase. *)
+      proto3_optional: bool option;(** If true, this is a proto3 "optional". When a proto3 field is optional, it
+       tracks presence regardless of field type.
+
+       When proto3_optional is true, this field must be belong to a oneof to
+       signal to old proto3 clients that presence is tracked for this field. This
+       oneof is known as a "synthetic" oneof, and this field must be its sole
+       member (each proto3 optional field gets its own synthetic oneof). Synthetic
+       oneofs exist in the descriptor only, and do not generate any API. Synthetic
+       oneofs must be ordered after all "real" oneofs.
+
+       For message fields, proto3_optional doesn't create any semantic change,
+       since non-repeated message fields always track presence. However it still
+       indicates the semantic detail of whether the user wrote "optional" or not.
+       This can be useful for round-tripping the .proto file. For consistency we
+       give message fields a synthetic oneof also, even though it is not required
+       to track presence. This is especially important because the parser can't
+       tell if a field is a message or an enum, so it must always create a
+       synthetic oneof.
+
+       Proto2 optional fields do not set this flag, because they already indicate
+       optional with `LABEL_OPTIONAL`. *)
+      }
       type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a oneof. *)
     and OneofDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; options: OneofOptions.t option }
+      type t = {
+      name: string option;
+      options: OneofOptions.t option;
+      }
       type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes an enum type. *)
     and EnumDescriptorProto : sig
+
+      (**
+         Range of reserved numeric values. Reserved values may not be used by
+         entries in the same enum. Reserved ranges may not overlap.
+
+         Note that this is distinct from DescriptorProto.ReservedRange in that it
+         is inclusive such that it can appropriately represent the entire int32
+         domain.
+      *)
       module rec EnumReservedRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Inclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
+      type t = {
+      name: string option;
+      value: EnumValueDescriptorProto.t list;
+      options: EnumOptions.t option;
+      reserved_range: EnumReservedRange.t list;(** Range of reserved numeric values. Reserved numeric values may not be used
+       by enum values in the same enum declaration. Reserved ranges may not
+       overlap. *)
+      reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
+       be reserved once. *)
+      }
       type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a value within an enum. *)
     and EnumValueDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; number: int option; options: EnumValueOptions.t option }
+      type t = {
+      name: string option;
+      number: int option;
+      options: EnumValueOptions.t option;
+      }
       type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a service. *)
     and ServiceDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
+      type t = {
+      name: string option;
+      method': MethodDescriptorProto.t list;
+      options: ServiceOptions.t option;
+      }
       type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (** Describes a method of a service. *)
     and MethodDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
+      type t = {
+      name: string option;
+      input_type: string option;(** Input and output type names.  These are resolved in the same way as
+       FieldDescriptorProto.type_name, but must refer to a message type. *)
+      output_type: string option;
+      options: MethodOptions.t option;
+      client_streaming: bool;(** Identifies if client streams multiple client messages *)
+      server_streaming: bool;(** Identifies if server streams multiple server messages *)
+      }
       type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and FileOptions : sig
+
+      (** Generated classes can be optimized for speed or code size. *)
       module rec OptimizeMode : sig
-        type t = SPEED | CODE_SIZE | LITE_RUNTIME
+        type t =
+          | SPEED
+          (** Generate complete code for parsing, serialization, *)
+          | CODE_SIZE
+          (**
+             etc.
+
+             Use ReflectionOps to implement these methods.
+          *)
+          | LITE_RUNTIME
+          (** Generate code using MessageLite and the lite runtime. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"]; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      java_package: string option;(** Sets the Java package where classes generated from this .proto will be
+       placed.  By default, the proto package is used, but this is often
+       inappropriate because proto packages do not normally start with backwards
+       domain names. *)
+      java_outer_classname: string option;(** Controls the name of the wrapper Java class generated for the .proto file.
+       That class will always contain the .proto file's getDescriptor() method as
+       well as any top-level extensions defined in the .proto file.
+       If java_multiple_files is disabled, then all the other classes from the
+       .proto file will be nested inside the single wrapper outer class. *)
+      optimize_for: OptimizeMode.t;(** Clients can define custom options in extensions of this message.
+       See the documentation for the "Options" section above. *)
+      java_multiple_files: bool;(** If enabled, then the Java code generator will generate a separate .java
+       file for each top-level message, enum, and service defined in the .proto
+       file.  Thus, these types will *not* be nested inside the wrapper class
+       named by java_outer_classname.  However, the wrapper class will still be
+       generated to contain the file's getDescriptor() method as well as any
+       top-level extensions defined in the file. *)
+      go_package: string option;(** Sets the Go package where structs generated from this .proto will be
+       placed. If omitted, the Go package will be derived from the following:
+         - The basename of the package import path, if provided.
+         - Otherwise, the package statement in the .proto file, if present.
+         - Otherwise, the basename of the .proto file, without extension. *)
+      cc_generic_services: bool;(** Should generic services be generated in each language?  "Generic" services
+       are not specific to any particular RPC system.  They are generated by the
+       main code generators in each language (without additional plugins).
+       Generic services were the only kind of service generation supported by
+       early versions of google.protobuf.
+
+       Generic services are now considered deprecated in favor of using plugins
+       that generate code specific to your particular RPC system.  Therefore,
+       these default to false.  Old code which depends on generic services should
+       explicitly set them to true. *)
+      java_generic_services: bool;
+      py_generic_services: bool;
+      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"];(** This option does nothing.
+      @deprecated deprecated in proto file *)
+      deprecated: bool;(** Is this file deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for everything in the file, or it will be completely ignored; in the very
+       least, this is a formalization for deprecating files. *)
+      java_string_check_utf8: bool;(** If set true, then the Java2 code generator will generate code that
+       throws an exception whenever an attempt is made to assign a non-UTF-8
+       byte sequence to a string field.
+       Message reflection will do the same.
+       However, an extension field still accepts non-UTF-8 byte sequences.
+       This option has no effect on when used with the lite runtime. *)
+      cc_enable_arenas: bool;(** Enables the use of arenas for the proto messages in this file. This applies
+       only to generated classes for C++. *)
+      objc_class_prefix: string option;(** Sets the objective c class prefix which is prepended to all objective c
+       generated classes from this .proto. There is no default. *)
+      csharp_namespace: string option;(** Namespace for generated classes; defaults to the package. *)
+      swift_prefix: string option;(** By default Swift generators will take the proto package and CamelCase it
+       replacing '.' with underscore and use that to prefix the types/symbols
+       defined. When this options is provided, they will use this value instead
+       to prefix the types/symbols defined. *)
+      php_class_prefix: string option;(** Sets the php class prefix which is prepended to all php generated classes
+       from this .proto. Default is empty. *)
+      php_namespace: string option;(** Use this option to change the namespace of php generated classes. Default
+       is empty. When this option is empty, the package name will be used for
+       determining the namespace. *)
+      php_generic_services: bool;
+      php_metadata_namespace: string option;(** Use this option to change the namespace of php generated metadata classes.
+       Default is empty. When this option is empty, the proto file name will be
+       used for determining the namespace. *)
+      ruby_package: string option;(** Use this option to change the package of ruby generated classes. Default
+       is empty. When this option is not set, the package name will be used for
+       determining the ruby package. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here.
+       See the documentation for the "Options" section above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and MessageOptions : sig
-      val name: unit -> string
-      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      message_set_wire_format: bool;(** Set true to use the old proto1 MessageSet wire format for extensions.
+       This is provided for backwards-compatibility with the MessageSet wire
+       format.  You should not use this for any other reason:  It's less
+       efficient, has fewer features, and is more complicated.
+
+       The message must be defined exactly as follows:
+         message Foo \{
+           option message_set_wire_format = true;
+           extensions 4 to max;
+         \}
+       Note that the message cannot have any defined fields; MessageSets only
+       have extensions.
+
+       All extensions of your type must be singular messages; e.g. they cannot
+       be int32s, enums, or repeated messages.
+
+       Because this is an option, the above two restrictions are not enforced by
+       the protocol compiler. *)
+      no_standard_descriptor_accessor: bool;(** Disables the generation of the standard "descriptor()" accessor, which can
+       conflict with a field of the same name.  This is meant to make migration
+       from proto1 easier; new code should avoid fields named "descriptor". *)
+      deprecated: bool;(** Is this message deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the message, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating messages. *)
+      map_entry: bool option;(** Whether the message is an automatically generated map entry type for the
+       maps field.
+
+       For maps fields:
+           map<KeyType, ValueType> map_field = 1;
+       The parsed descriptor looks like:
+           message MapFieldEntry \{
+               option map_entry = true;
+               optional KeyType key = 1;
+               optional ValueType value = 2;
+           \}
+           repeated MapFieldEntry map_field = 1;
+
+       Implementations may choose not to generate the map_entry=true message, but
+       use a native map in the target language to hold the keys and values.
+       The reflection APIs in such implementations still need to work as
+       if the field is a repeated message field.
+
+       NOTE: Do not set the option in .proto files. Always use the maps syntax
+       instead. The option should only be implicitly set by the proto compiler
+       parser. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and FieldOptions : sig
       module rec CType : sig
-        type t = STRING | CORD | STRING_PIECE
+        type t =
+          | STRING
+          (** Default mode. *)
+          | CORD
+          | STRING_PIECE
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
       and JSType : sig
-        type t = JS_NORMAL | JS_STRING | JS_NUMBER
+        type t =
+          | JS_NORMAL
+          (** Use the default type. *)
+          | JS_STRING
+          (** Use JavaScript strings. *)
+          | JS_NUMBER
+          (** Use JavaScript numbers. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      ctype: CType.t;(** The ctype option instructs the C++ code generator to use a different
+       representation of the field than it normally would.  See the specific
+       options below.  This option is not yet implemented in the open source
+       release -- sorry, we'll try to include it in a future version! *)
+      packed: bool option;(** The packed option can be enabled for repeated primitive fields to enable
+       a more efficient representation on the wire. Rather than repeatedly
+       writing the tag and type for each element, the entire array is encoded as
+       a single length-delimited blob. In proto3, only explicit setting it to
+       false will avoid using packed encoding. *)
+      deprecated: bool;(** Clients can define custom options in extensions of this message. See above. *)
+      lazy': bool;(** Should this field be parsed lazily?  Lazy applies only to message-type
+       fields.  It means that when the outer message is initially parsed, the
+       inner message's contents will not be parsed but instead stored in encoded
+       form.  The inner message will actually be parsed when it is first accessed.
+
+       This is only a hint.  Implementations are free to choose whether to use
+       eager or lazy parsing regardless of the value of this option.  However,
+       setting this option true suggests that the protocol author believes that
+       using lazy parsing on this field is worth the additional bookkeeping
+       overhead typically needed to implement it.
+
+       This option does not affect the public interface of any generated code;
+       all method signatures remain the same.  Furthermore, thread-safety of the
+       interface is not affected by this option; const methods remain safe to
+       call from multiple threads concurrently, while non-const methods continue
+       to require exclusive access.
+
+
+       Note that implementations may choose not to check required fields within
+       a lazy sub-message.  That is, calling IsInitialized() on the outer message
+       may return true even if the inner message has missing required fields.
+       This is necessary because otherwise the inner message would have to be
+       parsed in order to perform the check, defeating the purpose of lazy
+       parsing.  An implementation which chooses not to check required fields
+       must be consistent about it.  That is, for any particular sub-message, the
+       implementation must either *always* check its required fields, or *never*
+       check its required fields, regardless of whether or not the message has
+       been parsed.
+
+       As of 2021, lazy does no correctness checks on the byte stream during
+       parsing.  This may lead to crashes if and when an invalid byte stream is
+       finally parsed upon access.
+
+       TODO(b/211906113):  Enable validation on lazy fields. *)
+      jstype: JSType.t;(** The jstype option determines the JavaScript type used for values of the
+       field.  The option is permitted only for 64 bit integral and fixed types
+       (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+       is represented as JavaScript string, which avoids loss of precision that
+       can happen when a large value is converted to a floating point JavaScript.
+       Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+       use the JavaScript "number" type.  The behavior of the default option
+       JS_NORMAL is implementation dependent.
+
+       This option is an enum to permit additional types to be added, e.g.
+       goog.math.Integer. *)
+      weak: bool;(** For Google-internal migration only. Do not use. *)
+      unverified_lazy: bool;(** unverified_lazy does no correctness checks on the byte stream. This should
+       only be used where lazy with verification is prohibitive for performance
+       reasons. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and OneofOptions : sig
-      val name: unit -> string
-      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and EnumOptions : sig
-      val name: unit -> string
-      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      allow_alias: bool option;(** Set this option to true to allow mapping different tag names to the same
+       value. *)
+      deprecated: bool;(** Is this enum deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the enum, or it will be completely ignored; in the very least, this
+       is a formalization for deprecating enums. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and EnumValueOptions : sig
-      val name: unit -> string
-      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this enum value deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the enum value, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating enum values. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and ServiceOptions : sig
-      val name: unit -> string
-      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this service deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the service, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating services. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
     and MethodOptions : sig
+
+      (**
+         Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+         or neither? HTTP based RPC implementation may choose GET verb for safe
+         methods, and PUT verb for idempotent methods instead of the default POST.
+      *)
       module rec IdempotencyLevel : sig
-        type t = IDEMPOTENCY_UNKNOWN | NO_SIDE_EFFECTS | IDEMPOTENT
+        type t =
+          | IDEMPOTENCY_UNKNOWN
+          | NO_SIDE_EFFECTS
+          (** implies idempotent *)
+          | IDEMPOTENT
+          (** idempotent, but may have side effects *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this method deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the method, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating methods. *)
+      idempotency_level: IdempotencyLevel.t;
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (**
+       A message representing a option the parser does not recognize. This only
+       appears in options protos created by the compiler::Parser class.
+       DescriptorPool resolves these when building Descriptor objects. Therefore,
+       options protos in descriptor objects (e.g. returned by Descriptor::options(),
+       or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+       in them.
+    *)
     and UninterpretedOption : sig
+
+      (**
+         The name of the uninterpreted option.  Each string represents a segment in
+         a dot-separated name.  is_extension is true iff a segment represents an
+         extension (denoted with parentheses in options specs in .proto files).
+         E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
+         "foo.(bar.baz).moo".
+      *)
       module rec NamePart : sig
-        val name: unit -> string
-        type t = { name_part: string; is_extension: bool }
+        type t = {
+        name_part: string;
+        is_extension: bool;
+        }
         type make_t = name_part:string -> is_extension:bool -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
+      type t = {
+      name: NamePart.t list;
+      identifier_value: string option;(** The value of the uninterpreted option, in whatever type the tokenizer
+       identified it as during parsing. Exactly one of these should be set. *)
+      positive_int_value: int option;
+      negative_int_value: int option;
+      double_value: float option;
+      string_value: bytes option;
+      aggregate_value: string option;
+      }
       type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (**
+       Encapsulates information about the original source file from which a
+       FileDescriptorProto was generated.
+    *)
     and SourceCodeInfo : sig
       module rec Location : sig
-        val name: unit -> string
-        type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
+        type t = {
+        path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
+         location.
+
+         Each element is a field number or an index.  They form a path from
+         the root FileDescriptorProto to the place where the definition occurs.
+         For example, this path:
+           \[ 4, 3, 2, 7, 1 \]
+         refers to:
+           file.message_type(3)  // 4, 3
+               .field(7)         // 2, 7
+               .name()           // 1
+         This is because FileDescriptorProto.message_type has field number 4:
+           repeated DescriptorProto message_type = 4;
+         and DescriptorProto.field has field number 2:
+           repeated FieldDescriptorProto field = 2;
+         and FieldDescriptorProto.name has field number 1:
+           optional string name = 1;
+
+         Thus, the above path gives the location of a field name.  If we removed
+         the last element:
+           \[ 4, 3, 2, 7 \]
+         this path refers to the whole field declaration (from the beginning
+         of the label to the terminating semicolon). *)
+        span: int list;(** Always has exactly three or four elements: start line, start column,
+         end line (optional, otherwise assumed same as start line), end column.
+         These are packed into a single field for efficiency.  Note that line
+         and column numbers are zero-based -- typically you will want to add
+         1 to each before displaying to a user. *)
+        leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
+         comments appearing before and after the declaration which appear to be
+         attached to the declaration.
+
+         A series of line comments appearing on consecutive lines, with no other
+         tokens appearing on those lines, will be treated as a single comment.
+
+         leading_detached_comments will keep paragraphs of comments that appear
+         before (but not connected to) the current element. Each paragraph,
+         separated by empty lines, will be one comment element in the repeated
+         field.
+
+         Only the comment content is provided; comment markers (e.g. //) are
+         stripped out.  For block comments, leading whitespace and an asterisk
+         will be stripped from the beginning of each line other than the first.
+         Newlines are included in the output.
+
+         Examples:
+
+           optional int32 foo = 1;  // Comment attached to foo.
+           // Comment attached to bar.
+           optional int32 bar = 2;
+
+           optional string baz = 3;
+           // Comment attached to baz.
+           // Another line attached to baz.
+
+           // Comment attached to moo.
+           //
+           // Another line attached to moo.
+           optional double moo = 4;
+
+           // Detached comment for corge. This is not leading or trailing comments
+           // to moo or corge because there are blank lines separating it from
+           // both.
+
+           // Detached comment for corge paragraph 2.
+
+           optional string corge = 5;
+           /* Block comment attached
+            * to corge.  Leading asterisks
+            * will be removed. */
+           /* Block comment attached to
+            * grault. */
+           optional int32 grault = 6;
+
+           // ignored detached comments. *)
+        trailing_comments: string option;
+        leading_detached_comments: string list;
+        }
         type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
       type t = (Location.t list)
+      (**
+      @param location A Location identifies a piece of source code in a .proto file which
+       corresponds to a particular definition.  This information is intended
+       to be useful to IDEs, code indexers, documentation generators, and similar
+       tools.
+
+       For example, say we have a file like:
+         message Foo \{
+           optional string foo = 1;
+         \}
+       Let's look at just the field definition:
+         optional string foo = 1;
+         ^       ^^     ^^  ^  ^^^
+         a       bc     de  f  ghi
+       We have the following locations:
+         span   path               represents
+         \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
+         \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
+         \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
+         \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
+         \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
+
+       Notes:
+       - A location may refer to a repeated field itself (i.e. not to any
+         particular index within it).  This is used whenever a set of elements are
+         logically enclosed in a single code segment.  For example, an entire
+         extend block (possibly containing multiple extension definitions) will
+         have an outer location whose path refers to the "extensions" repeated
+         field without an index.
+       - Multiple locations may have the same path.  This happens when a single
+         logical declaration is spread out across multiple places.  The most
+         obvious example is the "extend" block again -- there may be multiple
+         extend blocks in the same scope, each of which will have the same path.
+       - A location's span is not always a subset of its parent's span.  For
+         example, the "extendee" of an extension declaration appears at the
+         beginning of the "extend" block and is shared by all extensions within
+         the block.
+       - Just because a location's span is a subset of some other location's span
+         does not mean that it is a descendant.  For example, a "group" defines
+         both a type and a field in a single declaration.  Thus, the locations
+         corresponding to the type and field and their components will overlap.
+       - Code which tries to interpret locations should probably be designed to
+         ignore those that it doesn't understand, as more types of locations could
+         be recorded in the future.
+      *)
+
       type make_t = ?location:Location.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
+
+    (**
+       Describes the relationship between generated code and its original source
+       file. A GeneratedCodeInfo message is associated with only one generated
+       source file, but may contain references to different source .proto files.
+    *)
     and GeneratedCodeInfo : sig
       module rec Annotation : sig
-        val name: unit -> string
-        type t = { path: int list; source_file: string option; begin': int option; end': int option }
+        type t = {
+        path: int list;(** Identifies the element in the original source .proto file. This field
+         is formatted the same as SourceCodeInfo.Location.path. *)
+        source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
+        begin': int option;(** Identifies the starting offset in bytes in the generated code
+         that relates to the identified object. *)
+        end': int option;(** Identifies the ending offset in bytes in the generated code that
+         relates to the identified offset. The end offset should be one past
+         the last relevant byte (so the length of the text = end - begin). *)
+        }
         type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
       type t = (Annotation.t list)
+      (**
+      @param annotation An Annotation connects some span of text in generated code to an element
+       of its generating .proto file.
+      *)
+
       type make_t = ?annotation:Annotation.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end
   end = struct
     module rec FileDescriptorSet : sig
-      val name: unit -> string
       type t = (FileDescriptorProto.t list)
       type make_t = ?file:FileDescriptorProto.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = FileDescriptorSet
       let name () = ".google.protobuf.FileDescriptorSet"
       type t = (FileDescriptorProto.t list)
       type make_t = ?file:FileDescriptorProto.t list -> unit -> t
       let make ?(file = []) () = (file)
       let merge =
-        let merge_file = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "file", "file"), (message (module FileDescriptorProto)), not_packed) ) in
-        fun (t1_file) (t2_file) -> merge_file t1_file t2_file
+      let merge_file = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "file", "file"), (message (module FileDescriptorProto)), not_packed) ) in
+      fun (t1_file) (t2_file) -> merge_file t1_file t2_file
       let spec () = Runtime'.Spec.( repeated ((1, "file", "file"), (message (module FileDescriptorProto)), not_packed) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -939,50 +3011,101 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and FileDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
+      type t = {
+      name: string option;(** file name, relative to root of source tree *)
+      package: string option;(** e.g. "foo", "foo.bar", etc. *)
+      dependency: string list;(** Names of files imported by this file. *)
+      message_type: DescriptorProto.t list;(** All top-level definitions in this file. *)
+      enum_type: EnumDescriptorProto.t list;
+      service: ServiceDescriptorProto.t list;
+      extension: FieldDescriptorProto.t list;
+      options: FileOptions.t option;
+      source_code_info: SourceCodeInfo.t option;(** This field contains optional information about the original source code.
+       You may safely remove this entire field without harming runtime
+       functionality of the descriptors -- the information is needed only by
+       development tools. *)
+      public_dependency: int list;(** Indexes of the public imported files in the dependency list above. *)
+      weak_dependency: int list;(** Indexes of the weak imported files in the dependency list.
+       For Google-internal migration only. Do not use. *)
+      syntax: string option;(** The syntax of the proto file.
+       The supported values are "proto2" and "proto3". *)
+      }
       type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = FileDescriptorProto
       let name () = ".google.protobuf.FileDescriptorProto"
-      type t = { name: string option; package: string option; dependency: string list; message_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; service: ServiceDescriptorProto.t list; extension: FieldDescriptorProto.t list; options: FileOptions.t option; source_code_info: SourceCodeInfo.t option; public_dependency: int list; weak_dependency: int list; syntax: string option }
+      type t = {
+      name: string option;(** file name, relative to root of source tree *)
+      package: string option;(** e.g. "foo", "foo.bar", etc. *)
+      dependency: string list;(** Names of files imported by this file. *)
+      message_type: DescriptorProto.t list;(** All top-level definitions in this file. *)
+      enum_type: EnumDescriptorProto.t list;
+      service: ServiceDescriptorProto.t list;
+      extension: FieldDescriptorProto.t list;
+      options: FileOptions.t option;
+      source_code_info: SourceCodeInfo.t option;(** This field contains optional information about the original source code.
+       You may safely remove this entire field without harming runtime
+       functionality of the descriptors -- the information is needed only by
+       development tools. *)
+      public_dependency: int list;(** Indexes of the public imported files in the dependency list above. *)
+      weak_dependency: int list;(** Indexes of the weak imported files in the dependency list.
+       For Google-internal migration only. Do not use. *)
+      syntax: string option;(** The syntax of the proto file.
+       The supported values are "proto2" and "proto3". *)
+      }
       type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       let make ?name ?package ?(dependency = []) ?(message_type = []) ?(enum_type = []) ?(service = []) ?(extension = []) ?options ?source_code_info ?(public_dependency = []) ?(weak_dependency = []) ?syntax () = { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-        let merge_package = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "package", "package"), string) ) in
-        let merge_dependency = Runtime'.Merge.merge Runtime'.Spec.( repeated ((3, "dependency", "dependency"), string, not_packed) ) in
-        let merge_message_type = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "message_type", "messageType"), (message (module DescriptorProto)), not_packed) ) in
-        let merge_enum_type = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "enum_type", "enumType"), (message (module EnumDescriptorProto)), not_packed) ) in
-        let merge_service = Runtime'.Merge.merge Runtime'.Spec.( repeated ((6, "service", "service"), (message (module ServiceDescriptorProto)), not_packed) ) in
-        let merge_extension = Runtime'.Merge.merge Runtime'.Spec.( repeated ((7, "extension", "extension"), (message (module FieldDescriptorProto)), not_packed) ) in
-        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((8, "options", "options"), (message (module FileOptions))) ) in
-        let merge_source_code_info = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((9, "source_code_info", "sourceCodeInfo"), (message (module SourceCodeInfo))) ) in
-        let merge_public_dependency = Runtime'.Merge.merge Runtime'.Spec.( repeated ((10, "public_dependency", "publicDependency"), int32_int, not_packed) ) in
-        let merge_weak_dependency = Runtime'.Merge.merge Runtime'.Spec.( repeated ((11, "weak_dependency", "weakDependency"), int32_int, not_packed) ) in
-        let merge_syntax = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((12, "syntax", "syntax"), string) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          package = (merge_package t1.package t2.package);
-          dependency = (merge_dependency t1.dependency t2.dependency);
-          message_type = (merge_message_type t1.message_type t2.message_type);
-          enum_type = (merge_enum_type t1.enum_type t2.enum_type);
-          service = (merge_service t1.service t2.service);
-          extension = (merge_extension t1.extension t2.extension);
-          options = (merge_options t1.options t2.options);
-          source_code_info = (merge_source_code_info t1.source_code_info t2.source_code_info);
-          public_dependency = (merge_public_dependency t1.public_dependency t2.public_dependency);
-          weak_dependency = (merge_weak_dependency t1.weak_dependency t2.weak_dependency);
-          syntax = (merge_syntax t1.syntax t2.syntax);
-         }
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+      let merge_package = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "package", "package"), string) ) in
+      let merge_dependency = Runtime'.Merge.merge Runtime'.Spec.( repeated ((3, "dependency", "dependency"), string, not_packed) ) in
+      let merge_message_type = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "message_type", "messageType"), (message (module DescriptorProto)), not_packed) ) in
+      let merge_enum_type = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "enum_type", "enumType"), (message (module EnumDescriptorProto)), not_packed) ) in
+      let merge_service = Runtime'.Merge.merge Runtime'.Spec.( repeated ((6, "service", "service"), (message (module ServiceDescriptorProto)), not_packed) ) in
+      let merge_extension = Runtime'.Merge.merge Runtime'.Spec.( repeated ((7, "extension", "extension"), (message (module FieldDescriptorProto)), not_packed) ) in
+      let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((8, "options", "options"), (message (module FileOptions))) ) in
+      let merge_source_code_info = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((9, "source_code_info", "sourceCodeInfo"), (message (module SourceCodeInfo))) ) in
+      let merge_public_dependency = Runtime'.Merge.merge Runtime'.Spec.( repeated ((10, "public_dependency", "publicDependency"), int32_int, not_packed) ) in
+      let merge_weak_dependency = Runtime'.Merge.merge Runtime'.Spec.( repeated ((11, "weak_dependency", "weakDependency"), int32_int, not_packed) ) in
+      let merge_syntax = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((12, "syntax", "syntax"), string) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      package = (merge_package t1.package t2.package);
+      dependency = (merge_dependency t1.dependency t2.dependency);
+      message_type = (merge_message_type t1.message_type t2.message_type);
+      enum_type = (merge_enum_type t1.enum_type t2.enum_type);
+      service = (merge_service t1.service t2.service);
+      extension = (merge_extension t1.extension t2.extension);
+      options = (merge_options t1.options t2.options);
+      source_code_info = (merge_source_code_info t1.source_code_info t2.source_code_info);
+      public_dependency = (merge_public_dependency t1.public_dependency t2.public_dependency);
+      weak_dependency = (merge_weak_dependency t1.weak_dependency t2.weak_dependency);
+      syntax = (merge_syntax t1.syntax t2.syntax);
+       }
       let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: basic_opt ((2, "package", "package"), string) ^:: repeated ((3, "dependency", "dependency"), string, not_packed) ^:: repeated ((4, "message_type", "messageType"), (message (module DescriptorProto)), not_packed) ^:: repeated ((5, "enum_type", "enumType"), (message (module EnumDescriptorProto)), not_packed) ^:: repeated ((6, "service", "service"), (message (module ServiceDescriptorProto)), not_packed) ^:: repeated ((7, "extension", "extension"), (message (module FieldDescriptorProto)), not_packed) ^:: basic_opt ((8, "options", "options"), (message (module FileOptions))) ^:: basic_opt ((9, "source_code_info", "sourceCodeInfo"), (message (module SourceCodeInfo))) ^:: repeated ((10, "public_dependency", "publicDependency"), int32_int, not_packed) ^:: repeated ((11, "weak_dependency", "weakDependency"), int32_int, not_packed) ^:: basic_opt ((12, "syntax", "syntax"), string) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1003,73 +3126,164 @@ end = struct
     end
     and DescriptorProto : sig
       module rec ExtensionRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        options: ExtensionRangeOptions.t option;
+        }
         type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (**
+         Range of reserved tag numbers. Reserved tag numbers may not be used by
+         fields or extension ranges in the same message. Reserved ranges may
+         not overlap.
+      *)
       and ReservedRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      type t = {
+      name: string option;
+      field: FieldDescriptorProto.t list;
+      nested_type: t list;
+      enum_type: EnumDescriptorProto.t list;
+      extension_range: ExtensionRange.t list;
+      extension: FieldDescriptorProto.t list;
+      options: MessageOptions.t option;
+      oneof_decl: OneofDescriptorProto.t list;
+      reserved_range: ReservedRange.t list;
+      reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
+       A given name may only be reserved once. *)
+      }
+      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = DescriptorProto
       module rec ExtensionRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        options: ExtensionRangeOptions.t option;
+        }
         type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = ExtensionRange
         let name () = ".google.protobuf.DescriptorProto.ExtensionRange"
-        type t = { start: int option; end': int option; options: ExtensionRangeOptions.t option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        options: ExtensionRangeOptions.t option;
+        }
         type make_t = ?start:int -> ?end':int -> ?options:ExtensionRangeOptions.t -> unit -> t
         let make ?start ?end' ?options () = { start; end'; options }
         let merge =
-          let merge_start = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ) in
-          let merge_end' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "end", "end"), int32_int) ) in
-          let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "options", "options"), (message (module ExtensionRangeOptions))) ) in
-          fun t1 t2 -> {
-            start = (merge_start t1.start t2.start);
-            end' = (merge_end' t1.end' t2.end');
-            options = (merge_options t1.options t2.options);
-           }
+        let merge_start = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ) in
+        let merge_end' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "end", "end"), int32_int) ) in
+        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "options", "options"), (message (module ExtensionRangeOptions))) ) in
+        fun t1 t2 -> {
+        start = (merge_start t1.start t2.start);
+        end' = (merge_end' t1.end' t2.end');
+        options = (merge_options t1.options t2.options);
+         }
         let spec () = Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ^:: basic_opt ((2, "end", "end"), int32_int) ^:: basic_opt ((3, "options", "options"), (message (module ExtensionRangeOptions))) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1089,30 +3303,51 @@ end = struct
         let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
       end
       and ReservedRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = ReservedRange
         let name () = ".google.protobuf.DescriptorProto.ReservedRange"
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Exclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         let make ?start ?end' () = { start; end' }
         let merge =
-          let merge_start = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ) in
-          let merge_end' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "end", "end"), int32_int) ) in
-          fun t1 t2 -> {
-            start = (merge_start t1.start t2.start);
-            end' = (merge_end' t1.end' t2.end');
-           }
+        let merge_start = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ) in
+        let merge_end' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "end", "end"), int32_int) ) in
+        fun t1 t2 -> {
+        start = (merge_start t1.start t2.start);
+        end' = (merge_end' t1.end' t2.end');
+         }
         let spec () = Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ^:: basic_opt ((2, "end", "end"), int32_int) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1132,33 +3367,45 @@ end = struct
         let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
       end
       let name () = ".google.protobuf.DescriptorProto"
-      type t = { name: string option; field: FieldDescriptorProto.t list; nested_type: DescriptorProto.t list; enum_type: EnumDescriptorProto.t list; extension_range: ExtensionRange.t list; extension: FieldDescriptorProto.t list; options: MessageOptions.t option; oneof_decl: OneofDescriptorProto.t list; reserved_range: ReservedRange.t list; reserved_name: string list }
-      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
+      type t = {
+      name: string option;
+      field: FieldDescriptorProto.t list;
+      nested_type: t list;
+      enum_type: EnumDescriptorProto.t list;
+      extension_range: ExtensionRange.t list;
+      extension: FieldDescriptorProto.t list;
+      options: MessageOptions.t option;
+      oneof_decl: OneofDescriptorProto.t list;
+      reserved_range: ReservedRange.t list;
+      reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
+       A given name may only be reserved once. *)
+      }
+      type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       let make ?name ?(field = []) ?(nested_type = []) ?(enum_type = []) ?(extension_range = []) ?(extension = []) ?options ?(oneof_decl = []) ?(reserved_range = []) ?(reserved_name = []) () = { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-        let merge_field = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "field", "field"), (message (module FieldDescriptorProto)), not_packed) ) in
-        let merge_nested_type = Runtime'.Merge.merge Runtime'.Spec.( repeated ((3, "nested_type", "nestedType"), (message (module DescriptorProto)), not_packed) ) in
-        let merge_enum_type = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "enum_type", "enumType"), (message (module EnumDescriptorProto)), not_packed) ) in
-        let merge_extension_range = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "extension_range", "extensionRange"), (message (module ExtensionRange)), not_packed) ) in
-        let merge_extension = Runtime'.Merge.merge Runtime'.Spec.( repeated ((6, "extension", "extension"), (message (module FieldDescriptorProto)), not_packed) ) in
-        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((7, "options", "options"), (message (module MessageOptions))) ) in
-        let merge_oneof_decl = Runtime'.Merge.merge Runtime'.Spec.( repeated ((8, "oneof_decl", "oneofDecl"), (message (module OneofDescriptorProto)), not_packed) ) in
-        let merge_reserved_range = Runtime'.Merge.merge Runtime'.Spec.( repeated ((9, "reserved_range", "reservedRange"), (message (module ReservedRange)), not_packed) ) in
-        let merge_reserved_name = Runtime'.Merge.merge Runtime'.Spec.( repeated ((10, "reserved_name", "reservedName"), string, not_packed) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          field = (merge_field t1.field t2.field);
-          nested_type = (merge_nested_type t1.nested_type t2.nested_type);
-          enum_type = (merge_enum_type t1.enum_type t2.enum_type);
-          extension_range = (merge_extension_range t1.extension_range t2.extension_range);
-          extension = (merge_extension t1.extension t2.extension);
-          options = (merge_options t1.options t2.options);
-          oneof_decl = (merge_oneof_decl t1.oneof_decl t2.oneof_decl);
-          reserved_range = (merge_reserved_range t1.reserved_range t2.reserved_range);
-          reserved_name = (merge_reserved_name t1.reserved_name t2.reserved_name);
-         }
-      let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: repeated ((2, "field", "field"), (message (module FieldDescriptorProto)), not_packed) ^:: repeated ((3, "nested_type", "nestedType"), (message (module DescriptorProto)), not_packed) ^:: repeated ((4, "enum_type", "enumType"), (message (module EnumDescriptorProto)), not_packed) ^:: repeated ((5, "extension_range", "extensionRange"), (message (module ExtensionRange)), not_packed) ^:: repeated ((6, "extension", "extension"), (message (module FieldDescriptorProto)), not_packed) ^:: basic_opt ((7, "options", "options"), (message (module MessageOptions))) ^:: repeated ((8, "oneof_decl", "oneofDecl"), (message (module OneofDescriptorProto)), not_packed) ^:: repeated ((9, "reserved_range", "reservedRange"), (message (module ReservedRange)), not_packed) ^:: repeated ((10, "reserved_name", "reservedName"), string, not_packed) ^:: nil )
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+      let merge_field = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "field", "field"), (message (module FieldDescriptorProto)), not_packed) ) in
+      let merge_nested_type = Runtime'.Merge.merge Runtime'.Spec.( repeated ((3, "nested_type", "nestedType"), (message (module This'_)), not_packed) ) in
+      let merge_enum_type = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "enum_type", "enumType"), (message (module EnumDescriptorProto)), not_packed) ) in
+      let merge_extension_range = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "extension_range", "extensionRange"), (message (module ExtensionRange)), not_packed) ) in
+      let merge_extension = Runtime'.Merge.merge Runtime'.Spec.( repeated ((6, "extension", "extension"), (message (module FieldDescriptorProto)), not_packed) ) in
+      let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((7, "options", "options"), (message (module MessageOptions))) ) in
+      let merge_oneof_decl = Runtime'.Merge.merge Runtime'.Spec.( repeated ((8, "oneof_decl", "oneofDecl"), (message (module OneofDescriptorProto)), not_packed) ) in
+      let merge_reserved_range = Runtime'.Merge.merge Runtime'.Spec.( repeated ((9, "reserved_range", "reservedRange"), (message (module ReservedRange)), not_packed) ) in
+      let merge_reserved_name = Runtime'.Merge.merge Runtime'.Spec.( repeated ((10, "reserved_name", "reservedName"), string, not_packed) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      field = (merge_field t1.field t2.field);
+      nested_type = (merge_nested_type t1.nested_type t2.nested_type);
+      enum_type = (merge_enum_type t1.enum_type t2.enum_type);
+      extension_range = (merge_extension_range t1.extension_range t2.extension_range);
+      extension = (merge_extension t1.extension t2.extension);
+      options = (merge_options t1.options t2.options);
+      oneof_decl = (merge_oneof_decl t1.oneof_decl t2.oneof_decl);
+      reserved_range = (merge_reserved_range t1.reserved_range t2.reserved_range);
+      reserved_name = (merge_reserved_name t1.reserved_name t2.reserved_name);
+       }
+      let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: repeated ((2, "field", "field"), (message (module FieldDescriptorProto)), not_packed) ^:: repeated ((3, "nested_type", "nestedType"), (message (module This'_)), not_packed) ^:: repeated ((4, "enum_type", "enumType"), (message (module EnumDescriptorProto)), not_packed) ^:: repeated ((5, "extension_range", "extensionRange"), (message (module ExtensionRange)), not_packed) ^:: repeated ((6, "extension", "extension"), (message (module FieldDescriptorProto)), not_packed) ^:: basic_opt ((7, "options", "options"), (message (module MessageOptions))) ^:: repeated ((8, "oneof_decl", "oneofDecl"), (message (module OneofDescriptorProto)), not_packed) ^:: repeated ((9, "reserved_range", "reservedRange"), (message (module ReservedRange)), not_packed) ^:: repeated ((10, "reserved_name", "reservedName"), string, not_packed) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
         fun writer { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name } -> serialize writer name field nested_type enum_type extension_range extension options oneof_decl reserved_range reserved_name
@@ -1177,29 +3424,50 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and ExtensionRangeOptions : sig
-      val name: unit -> string
-      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = ExtensionRangeOptions
       let name () = ".google.protobuf.ExtensionRangeOptions"
-      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
       let merge =
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1220,46 +3488,247 @@ end = struct
     end
     and FieldDescriptorProto : sig
       module rec Type : sig
-        type t = TYPE_DOUBLE | TYPE_FLOAT | TYPE_INT64 | TYPE_UINT64 | TYPE_INT32 | TYPE_FIXED64 | TYPE_FIXED32 | TYPE_BOOL | TYPE_STRING | TYPE_GROUP | TYPE_MESSAGE | TYPE_BYTES | TYPE_UINT32 | TYPE_ENUM | TYPE_SFIXED32 | TYPE_SFIXED64 | TYPE_SINT32 | TYPE_SINT64
+        type t =
+          | TYPE_DOUBLE
+          (**
+             0 is reserved for errors.
+             Order is weird for historical reasons.
+          *)
+          | TYPE_FLOAT
+          | TYPE_INT64
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+             negative values are likely.
+          *)
+          | TYPE_UINT64
+          | TYPE_INT32
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+             negative values are likely.
+          *)
+          | TYPE_FIXED64
+          | TYPE_FIXED32
+          | TYPE_BOOL
+          | TYPE_STRING
+          | TYPE_GROUP
+          (**
+             Tag-delimited aggregate.
+             Group type is deprecated and not supported in proto3. However, Proto3
+             implementations should still be able to parse the group wire format and
+             treat group fields as unknown fields.
+          *)
+          | TYPE_MESSAGE
+          (** Length-delimited aggregate. *)
+          | TYPE_BYTES
+          (** New in version 2. *)
+          | TYPE_UINT32
+          | TYPE_ENUM
+          | TYPE_SFIXED32
+          | TYPE_SFIXED64
+          | TYPE_SINT32
+          (** Uses ZigZag encoding. *)
+          | TYPE_SINT64
+          (** Uses ZigZag encoding. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
       and Label : sig
-        type t = LABEL_OPTIONAL | LABEL_REQUIRED | LABEL_REPEATED
+        type t =
+          | LABEL_OPTIONAL
+          (** 0 is reserved for errors *)
+          | LABEL_REQUIRED
+          | LABEL_REPEATED
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
+      type t = {
+      name: string option;
+      extendee: string option;(** For extensions, this is the name of the type being extended.  It is
+       resolved in the same manner as type_name. *)
+      number: int option;
+      label: Label.t option;
+      type': Type.t option;(** If type_name is set, this need not be set.  If both this and type_name
+       are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
+      type_name: string option;(** For message and enum types, this is the name of the type.  If the name
+       starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+       rules are used to find the type (i.e. first the nested types within this
+       message are searched, then within the parent, on up to the root
+       namespace). *)
+      default_value: string option;(** For numeric types, contains the original text representation of the value.
+       For booleans, "true" or "false".
+       For strings, contains the default text contents (not escaped in any way).
+       For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
+      options: FieldOptions.t option;
+      oneof_index: int option;(** If set, gives the index of a oneof in the containing type's oneof_decl
+       list.  This field is a member of that oneof. *)
+      json_name: string option;(** JSON name of this field. The value is set by protocol compiler. If the
+       user has set a "json_name" option on this field, that option's value
+       will be used. Otherwise, it's deduced from the field's name by converting
+       it to camelCase. *)
+      proto3_optional: bool option;(** If true, this is a proto3 "optional". When a proto3 field is optional, it
+       tracks presence regardless of field type.
+
+       When proto3_optional is true, this field must be belong to a oneof to
+       signal to old proto3 clients that presence is tracked for this field. This
+       oneof is known as a "synthetic" oneof, and this field must be its sole
+       member (each proto3 optional field gets its own synthetic oneof). Synthetic
+       oneofs exist in the descriptor only, and do not generate any API. Synthetic
+       oneofs must be ordered after all "real" oneofs.
+
+       For message fields, proto3_optional doesn't create any semantic change,
+       since non-repeated message fields always track presence. However it still
+       indicates the semantic detail of whether the user wrote "optional" or not.
+       This can be useful for round-tripping the .proto file. For consistency we
+       give message fields a synthetic oneof also, even though it is not required
+       to track presence. This is especially important because the parser can't
+       tell if a field is a message or an enum, so it must always create a
+       synthetic oneof.
+
+       Proto2 optional fields do not set this flag, because they already indicate
+       optional with `LABEL_OPTIONAL`. *)
+      }
       type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = FieldDescriptorProto
       module rec Type : sig
-        type t = TYPE_DOUBLE | TYPE_FLOAT | TYPE_INT64 | TYPE_UINT64 | TYPE_INT32 | TYPE_FIXED64 | TYPE_FIXED32 | TYPE_BOOL | TYPE_STRING | TYPE_GROUP | TYPE_MESSAGE | TYPE_BYTES | TYPE_UINT32 | TYPE_ENUM | TYPE_SFIXED32 | TYPE_SFIXED64 | TYPE_SINT32 | TYPE_SINT64
+        type t =
+          | TYPE_DOUBLE
+          (**
+             0 is reserved for errors.
+             Order is weird for historical reasons.
+          *)
+          | TYPE_FLOAT
+          | TYPE_INT64
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+             negative values are likely.
+          *)
+          | TYPE_UINT64
+          | TYPE_INT32
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+             negative values are likely.
+          *)
+          | TYPE_FIXED64
+          | TYPE_FIXED32
+          | TYPE_BOOL
+          | TYPE_STRING
+          | TYPE_GROUP
+          (**
+             Tag-delimited aggregate.
+             Group type is deprecated and not supported in proto3. However, Proto3
+             implementations should still be able to parse the group wire format and
+             treat group fields as unknown fields.
+          *)
+          | TYPE_MESSAGE
+          (** Length-delimited aggregate. *)
+          | TYPE_BYTES
+          (** New in version 2. *)
+          | TYPE_UINT32
+          | TYPE_ENUM
+          | TYPE_SFIXED32
+          | TYPE_SFIXED64
+          | TYPE_SINT32
+          (** Uses ZigZag encoding. *)
+          | TYPE_SINT64
+          (** Uses ZigZag encoding. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end = struct
-        type t = TYPE_DOUBLE | TYPE_FLOAT | TYPE_INT64 | TYPE_UINT64 | TYPE_INT32 | TYPE_FIXED64 | TYPE_FIXED32 | TYPE_BOOL | TYPE_STRING | TYPE_GROUP | TYPE_MESSAGE | TYPE_BYTES | TYPE_UINT32 | TYPE_ENUM | TYPE_SFIXED32 | TYPE_SFIXED64 | TYPE_SINT32 | TYPE_SINT64
+        module This'_ = Type
+        type t =
+          | TYPE_DOUBLE
+          (**
+             0 is reserved for errors.
+             Order is weird for historical reasons.
+          *)
+          | TYPE_FLOAT
+          | TYPE_INT64
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+             negative values are likely.
+          *)
+          | TYPE_UINT64
+          | TYPE_INT32
+          (**
+             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+             negative values are likely.
+          *)
+          | TYPE_FIXED64
+          | TYPE_FIXED32
+          | TYPE_BOOL
+          | TYPE_STRING
+          | TYPE_GROUP
+          (**
+             Tag-delimited aggregate.
+             Group type is deprecated and not supported in proto3. However, Proto3
+             implementations should still be able to parse the group wire format and
+             treat group fields as unknown fields.
+          *)
+          | TYPE_MESSAGE
+          (** Length-delimited aggregate. *)
+          | TYPE_BYTES
+          (** New in version 2. *)
+          | TYPE_UINT32
+          | TYPE_ENUM
+          | TYPE_SFIXED32
+          | TYPE_SFIXED64
+          | TYPE_SINT32
+          (** Uses ZigZag encoding. *)
+          | TYPE_SINT64
+          (** Uses ZigZag encoding. *)
+
         let name () = ".google.protobuf.FieldDescriptorProto.Type"
         let to_int = function
           | TYPE_DOUBLE -> 1
@@ -1343,15 +3812,30 @@ end = struct
 
       end
       and Label : sig
-        type t = LABEL_OPTIONAL | LABEL_REQUIRED | LABEL_REPEATED
+        type t =
+          | LABEL_OPTIONAL
+          (** 0 is reserved for errors *)
+          | LABEL_REQUIRED
+          | LABEL_REPEATED
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end = struct
-        type t = LABEL_OPTIONAL | LABEL_REQUIRED | LABEL_REPEATED
+        module This'_ = Label
+        type t =
+          | LABEL_OPTIONAL
+          (** 0 is reserved for errors *)
+          | LABEL_REQUIRED
+          | LABEL_REPEATED
+
         let name () = ".google.protobuf.FieldDescriptorProto.Label"
         let to_int = function
           | LABEL_OPTIONAL -> 1
@@ -1375,34 +3859,79 @@ end = struct
 
       end
       let name () = ".google.protobuf.FieldDescriptorProto"
-      type t = { name: string option; extendee: string option; number: int option; label: Label.t option; type': Type.t option; type_name: string option; default_value: string option; options: FieldOptions.t option; oneof_index: int option; json_name: string option; proto3_optional: bool option }
+      type t = {
+      name: string option;
+      extendee: string option;(** For extensions, this is the name of the type being extended.  It is
+       resolved in the same manner as type_name. *)
+      number: int option;
+      label: Label.t option;
+      type': Type.t option;(** If type_name is set, this need not be set.  If both this and type_name
+       are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
+      type_name: string option;(** For message and enum types, this is the name of the type.  If the name
+       starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+       rules are used to find the type (i.e. first the nested types within this
+       message are searched, then within the parent, on up to the root
+       namespace). *)
+      default_value: string option;(** For numeric types, contains the original text representation of the value.
+       For booleans, "true" or "false".
+       For strings, contains the default text contents (not escaped in any way).
+       For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
+      options: FieldOptions.t option;
+      oneof_index: int option;(** If set, gives the index of a oneof in the containing type's oneof_decl
+       list.  This field is a member of that oneof. *)
+      json_name: string option;(** JSON name of this field. The value is set by protocol compiler. If the
+       user has set a "json_name" option on this field, that option's value
+       will be used. Otherwise, it's deduced from the field's name by converting
+       it to camelCase. *)
+      proto3_optional: bool option;(** If true, this is a proto3 "optional". When a proto3 field is optional, it
+       tracks presence regardless of field type.
+
+       When proto3_optional is true, this field must be belong to a oneof to
+       signal to old proto3 clients that presence is tracked for this field. This
+       oneof is known as a "synthetic" oneof, and this field must be its sole
+       member (each proto3 optional field gets its own synthetic oneof). Synthetic
+       oneofs exist in the descriptor only, and do not generate any API. Synthetic
+       oneofs must be ordered after all "real" oneofs.
+
+       For message fields, proto3_optional doesn't create any semantic change,
+       since non-repeated message fields always track presence. However it still
+       indicates the semantic detail of whether the user wrote "optional" or not.
+       This can be useful for round-tripping the .proto file. For consistency we
+       give message fields a synthetic oneof also, even though it is not required
+       to track presence. This is especially important because the parser can't
+       tell if a field is a message or an enum, so it must always create a
+       synthetic oneof.
+
+       Proto2 optional fields do not set this flag, because they already indicate
+       optional with `LABEL_OPTIONAL`. *)
+      }
       type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       let make ?name ?extendee ?number ?label ?type' ?type_name ?default_value ?options ?oneof_index ?json_name ?proto3_optional () = { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-        let merge_extendee = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "extendee", "extendee"), string) ) in
-        let merge_number = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "number", "number"), int32_int) ) in
-        let merge_label = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "label", "label"), (enum (module Label))) ) in
-        let merge_type' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((5, "type", "type"), (enum (module Type))) ) in
-        let merge_type_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((6, "type_name", "typeName"), string) ) in
-        let merge_default_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((7, "default_value", "defaultValue"), string) ) in
-        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((8, "options", "options"), (message (module FieldOptions))) ) in
-        let merge_oneof_index = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((9, "oneof_index", "oneofIndex"), int32_int) ) in
-        let merge_json_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((10, "json_name", "jsonName"), string) ) in
-        let merge_proto3_optional = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((17, "proto3_optional", "proto3Optional"), bool) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          extendee = (merge_extendee t1.extendee t2.extendee);
-          number = (merge_number t1.number t2.number);
-          label = (merge_label t1.label t2.label);
-          type' = (merge_type' t1.type' t2.type');
-          type_name = (merge_type_name t1.type_name t2.type_name);
-          default_value = (merge_default_value t1.default_value t2.default_value);
-          options = (merge_options t1.options t2.options);
-          oneof_index = (merge_oneof_index t1.oneof_index t2.oneof_index);
-          json_name = (merge_json_name t1.json_name t2.json_name);
-          proto3_optional = (merge_proto3_optional t1.proto3_optional t2.proto3_optional);
-         }
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+      let merge_extendee = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "extendee", "extendee"), string) ) in
+      let merge_number = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "number", "number"), int32_int) ) in
+      let merge_label = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "label", "label"), (enum (module Label))) ) in
+      let merge_type' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((5, "type", "type"), (enum (module Type))) ) in
+      let merge_type_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((6, "type_name", "typeName"), string) ) in
+      let merge_default_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((7, "default_value", "defaultValue"), string) ) in
+      let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((8, "options", "options"), (message (module FieldOptions))) ) in
+      let merge_oneof_index = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((9, "oneof_index", "oneofIndex"), int32_int) ) in
+      let merge_json_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((10, "json_name", "jsonName"), string) ) in
+      let merge_proto3_optional = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((17, "proto3_optional", "proto3Optional"), bool) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      extendee = (merge_extendee t1.extendee t2.extendee);
+      number = (merge_number t1.number t2.number);
+      label = (merge_label t1.label t2.label);
+      type' = (merge_type' t1.type' t2.type');
+      type_name = (merge_type_name t1.type_name t2.type_name);
+      default_value = (merge_default_value t1.default_value t2.default_value);
+      options = (merge_options t1.options t2.options);
+      oneof_index = (merge_oneof_index t1.oneof_index t2.oneof_index);
+      json_name = (merge_json_name t1.json_name t2.json_name);
+      proto3_optional = (merge_proto3_optional t1.proto3_optional t2.proto3_optional);
+       }
       let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: basic_opt ((2, "extendee", "extendee"), string) ^:: basic_opt ((3, "number", "number"), int32_int) ^:: basic_opt ((4, "label", "label"), (enum (module Label))) ^:: basic_opt ((5, "type", "type"), (enum (module Type))) ^:: basic_opt ((6, "type_name", "typeName"), string) ^:: basic_opt ((7, "default_value", "defaultValue"), string) ^:: basic_opt ((8, "options", "options"), (message (module FieldOptions))) ^:: basic_opt ((9, "oneof_index", "oneofIndex"), int32_int) ^:: basic_opt ((10, "json_name", "jsonName"), string) ^:: basic_opt ((17, "proto3_optional", "proto3Optional"), bool) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1422,30 +3951,51 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and OneofDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; options: OneofOptions.t option }
+      type t = {
+      name: string option;
+      options: OneofOptions.t option;
+      }
       type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = OneofDescriptorProto
       let name () = ".google.protobuf.OneofDescriptorProto"
-      type t = { name: string option; options: OneofOptions.t option }
+      type t = {
+      name: string option;
+      options: OneofOptions.t option;
+      }
       type make_t = ?name:string -> ?options:OneofOptions.t -> unit -> t
       let make ?name ?options () = { name; options }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "options", "options"), (message (module OneofOptions))) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          options = (merge_options t1.options t2.options);
-         }
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+      let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "options", "options"), (message (module OneofOptions))) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      options = (merge_options t1.options t2.options);
+       }
       let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: basic_opt ((2, "options", "options"), (message (module OneofOptions))) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1465,58 +4015,129 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and EnumDescriptorProto : sig
+
+      (**
+         Range of reserved numeric values. Reserved values may not be used by
+         entries in the same enum. Reserved ranges may not overlap.
+
+         Note that this is distinct from DescriptorProto.ReservedRange in that it
+         is inclusive such that it can appropriately represent the entire int32
+         domain.
+      *)
       module rec EnumReservedRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Inclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
+      type t = {
+      name: string option;
+      value: EnumValueDescriptorProto.t list;
+      options: EnumOptions.t option;
+      reserved_range: EnumReservedRange.t list;(** Range of reserved numeric values. Reserved numeric values may not be used
+       by enum values in the same enum declaration. Reserved ranges may not
+       overlap. *)
+      reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
+       be reserved once. *)
+      }
       type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = EnumDescriptorProto
       module rec EnumReservedRange : sig
-        val name: unit -> string
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Inclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = EnumReservedRange
         let name () = ".google.protobuf.EnumDescriptorProto.EnumReservedRange"
-        type t = { start: int option; end': int option }
+        type t = {
+        start: int option;(** Inclusive. *)
+        end': int option;(** Inclusive. *)
+        }
         type make_t = ?start:int -> ?end':int -> unit -> t
         let make ?start ?end' () = { start; end' }
         let merge =
-          let merge_start = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ) in
-          let merge_end' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "end", "end"), int32_int) ) in
-          fun t1 t2 -> {
-            start = (merge_start t1.start t2.start);
-            end' = (merge_end' t1.end' t2.end');
-           }
+        let merge_start = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ) in
+        let merge_end' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "end", "end"), int32_int) ) in
+        fun t1 t2 -> {
+        start = (merge_start t1.start t2.start);
+        end' = (merge_end' t1.end' t2.end');
+         }
         let spec () = Runtime'.Spec.( basic_opt ((1, "start", "start"), int32_int) ^:: basic_opt ((2, "end", "end"), int32_int) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1536,22 +4157,31 @@ end = struct
         let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
       end
       let name () = ".google.protobuf.EnumDescriptorProto"
-      type t = { name: string option; value: EnumValueDescriptorProto.t list; options: EnumOptions.t option; reserved_range: EnumReservedRange.t list; reserved_name: string list }
+      type t = {
+      name: string option;
+      value: EnumValueDescriptorProto.t list;
+      options: EnumOptions.t option;
+      reserved_range: EnumReservedRange.t list;(** Range of reserved numeric values. Reserved numeric values may not be used
+       by enum values in the same enum declaration. Reserved ranges may not
+       overlap. *)
+      reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
+       be reserved once. *)
+      }
       type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       let make ?name ?(value = []) ?options ?(reserved_range = []) ?(reserved_name = []) () = { name; value; options; reserved_range; reserved_name }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-        let merge_value = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "value", "value"), (message (module EnumValueDescriptorProto)), not_packed) ) in
-        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "options", "options"), (message (module EnumOptions))) ) in
-        let merge_reserved_range = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "reserved_range", "reservedRange"), (message (module EnumReservedRange)), not_packed) ) in
-        let merge_reserved_name = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "reserved_name", "reservedName"), string, not_packed) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          value = (merge_value t1.value t2.value);
-          options = (merge_options t1.options t2.options);
-          reserved_range = (merge_reserved_range t1.reserved_range t2.reserved_range);
-          reserved_name = (merge_reserved_name t1.reserved_name t2.reserved_name);
-         }
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+      let merge_value = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "value", "value"), (message (module EnumValueDescriptorProto)), not_packed) ) in
+      let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "options", "options"), (message (module EnumOptions))) ) in
+      let merge_reserved_range = Runtime'.Merge.merge Runtime'.Spec.( repeated ((4, "reserved_range", "reservedRange"), (message (module EnumReservedRange)), not_packed) ) in
+      let merge_reserved_name = Runtime'.Merge.merge Runtime'.Spec.( repeated ((5, "reserved_name", "reservedName"), string, not_packed) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      value = (merge_value t1.value t2.value);
+      options = (merge_options t1.options t2.options);
+      reserved_range = (merge_reserved_range t1.reserved_range t2.reserved_range);
+      reserved_name = (merge_reserved_name t1.reserved_name t2.reserved_name);
+       }
       let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: repeated ((2, "value", "value"), (message (module EnumValueDescriptorProto)), not_packed) ^:: basic_opt ((3, "options", "options"), (message (module EnumOptions))) ^:: repeated ((4, "reserved_range", "reservedRange"), (message (module EnumReservedRange)), not_packed) ^:: repeated ((5, "reserved_name", "reservedName"), string, not_packed) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1571,32 +4201,55 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and EnumValueDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; number: int option; options: EnumValueOptions.t option }
+      type t = {
+      name: string option;
+      number: int option;
+      options: EnumValueOptions.t option;
+      }
       type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = EnumValueDescriptorProto
       let name () = ".google.protobuf.EnumValueDescriptorProto"
-      type t = { name: string option; number: int option; options: EnumValueOptions.t option }
+      type t = {
+      name: string option;
+      number: int option;
+      options: EnumValueOptions.t option;
+      }
       type make_t = ?name:string -> ?number:int -> ?options:EnumValueOptions.t -> unit -> t
       let make ?name ?number ?options () = { name; number; options }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-        let merge_number = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "number", "number"), int32_int) ) in
-        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "options", "options"), (message (module EnumValueOptions))) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          number = (merge_number t1.number t2.number);
-          options = (merge_options t1.options t2.options);
-         }
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+      let merge_number = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "number", "number"), int32_int) ) in
+      let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "options", "options"), (message (module EnumValueOptions))) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      number = (merge_number t1.number t2.number);
+      options = (merge_options t1.options t2.options);
+       }
       let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: basic_opt ((2, "number", "number"), int32_int) ^:: basic_opt ((3, "options", "options"), (message (module EnumValueOptions))) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1616,32 +4269,55 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and ServiceDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
+      type t = {
+      name: string option;
+      method': MethodDescriptorProto.t list;
+      options: ServiceOptions.t option;
+      }
       type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = ServiceDescriptorProto
       let name () = ".google.protobuf.ServiceDescriptorProto"
-      type t = { name: string option; method': MethodDescriptorProto.t list; options: ServiceOptions.t option }
+      type t = {
+      name: string option;
+      method': MethodDescriptorProto.t list;
+      options: ServiceOptions.t option;
+      }
       type make_t = ?name:string -> ?method':MethodDescriptorProto.t list -> ?options:ServiceOptions.t -> unit -> t
       let make ?name ?(method' = []) ?options () = { name; method'; options }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-        let merge_method' = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "method", "method"), (message (module MethodDescriptorProto)), not_packed) ) in
-        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "options", "options"), (message (module ServiceOptions))) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          method' = (merge_method' t1.method' t2.method');
-          options = (merge_options t1.options t2.options);
-         }
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+      let merge_method' = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "method", "method"), (message (module MethodDescriptorProto)), not_packed) ) in
+      let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "options", "options"), (message (module ServiceOptions))) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      method' = (merge_method' t1.method' t2.method');
+      options = (merge_options t1.options t2.options);
+       }
       let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: repeated ((2, "method", "method"), (message (module MethodDescriptorProto)), not_packed) ^:: basic_opt ((3, "options", "options"), (message (module ServiceOptions))) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1661,38 +4337,69 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and MethodDescriptorProto : sig
-      val name: unit -> string
-      type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
+      type t = {
+      name: string option;
+      input_type: string option;(** Input and output type names.  These are resolved in the same way as
+       FieldDescriptorProto.type_name, but must refer to a message type. *)
+      output_type: string option;
+      options: MethodOptions.t option;
+      client_streaming: bool;(** Identifies if client streams multiple client messages *)
+      server_streaming: bool;(** Identifies if server streams multiple server messages *)
+      }
       type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = MethodDescriptorProto
       let name () = ".google.protobuf.MethodDescriptorProto"
-      type t = { name: string option; input_type: string option; output_type: string option; options: MethodOptions.t option; client_streaming: bool; server_streaming: bool }
+      type t = {
+      name: string option;
+      input_type: string option;(** Input and output type names.  These are resolved in the same way as
+       FieldDescriptorProto.type_name, but must refer to a message type. *)
+      output_type: string option;
+      options: MethodOptions.t option;
+      client_streaming: bool;(** Identifies if client streams multiple client messages *)
+      server_streaming: bool;(** Identifies if server streams multiple server messages *)
+      }
       type make_t = ?name:string -> ?input_type:string -> ?output_type:string -> ?options:MethodOptions.t -> ?client_streaming:bool -> ?server_streaming:bool -> unit -> t
       let make ?name ?input_type ?output_type ?options ?(client_streaming = false) ?(server_streaming = false) () = { name; input_type; output_type; options; client_streaming; server_streaming }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-        let merge_input_type = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "input_type", "inputType"), string) ) in
-        let merge_output_type = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "output_type", "outputType"), string) ) in
-        let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "options", "options"), (message (module MethodOptions))) ) in
-        let merge_client_streaming = Runtime'.Merge.merge Runtime'.Spec.( basic ((5, "client_streaming", "clientStreaming"), bool, (false)) ) in
-        let merge_server_streaming = Runtime'.Merge.merge Runtime'.Spec.( basic ((6, "server_streaming", "serverStreaming"), bool, (false)) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          input_type = (merge_input_type t1.input_type t2.input_type);
-          output_type = (merge_output_type t1.output_type t2.output_type);
-          options = (merge_options t1.options t2.options);
-          client_streaming = (merge_client_streaming t1.client_streaming t2.client_streaming);
-          server_streaming = (merge_server_streaming t1.server_streaming t2.server_streaming);
-         }
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+      let merge_input_type = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "input_type", "inputType"), string) ) in
+      let merge_output_type = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "output_type", "outputType"), string) ) in
+      let merge_options = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "options", "options"), (message (module MethodOptions))) ) in
+      let merge_client_streaming = Runtime'.Merge.merge Runtime'.Spec.( basic ((5, "client_streaming", "clientStreaming"), bool, (false)) ) in
+      let merge_server_streaming = Runtime'.Merge.merge Runtime'.Spec.( basic ((6, "server_streaming", "serverStreaming"), bool, (false)) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      input_type = (merge_input_type t1.input_type t2.input_type);
+      output_type = (merge_output_type t1.output_type t2.output_type);
+      options = (merge_options t1.options t2.options);
+      client_streaming = (merge_client_streaming t1.client_streaming t2.client_streaming);
+      server_streaming = (merge_server_streaming t1.server_streaming t2.server_streaming);
+       }
       let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: basic_opt ((2, "input_type", "inputType"), string) ^:: basic_opt ((3, "output_type", "outputType"), string) ^:: basic_opt ((4, "options", "options"), (message (module MethodOptions))) ^:: basic ((5, "client_streaming", "clientStreaming"), bool, (false)) ^:: basic ((6, "server_streaming", "serverStreaming"), bool, (false)) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1712,38 +4419,168 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and FileOptions : sig
+
+      (** Generated classes can be optimized for speed or code size. *)
       module rec OptimizeMode : sig
-        type t = SPEED | CODE_SIZE | LITE_RUNTIME
+        type t =
+          | SPEED
+          (** Generate complete code for parsing, serialization, *)
+          | CODE_SIZE
+          (**
+             etc.
+
+             Use ReflectionOps to implement these methods.
+          *)
+          | LITE_RUNTIME
+          (** Generate code using MessageLite and the lite runtime. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"]; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      java_package: string option;(** Sets the Java package where classes generated from this .proto will be
+       placed.  By default, the proto package is used, but this is often
+       inappropriate because proto packages do not normally start with backwards
+       domain names. *)
+      java_outer_classname: string option;(** Controls the name of the wrapper Java class generated for the .proto file.
+       That class will always contain the .proto file's getDescriptor() method as
+       well as any top-level extensions defined in the .proto file.
+       If java_multiple_files is disabled, then all the other classes from the
+       .proto file will be nested inside the single wrapper outer class. *)
+      optimize_for: OptimizeMode.t;(** Clients can define custom options in extensions of this message.
+       See the documentation for the "Options" section above. *)
+      java_multiple_files: bool;(** If enabled, then the Java code generator will generate a separate .java
+       file for each top-level message, enum, and service defined in the .proto
+       file.  Thus, these types will *not* be nested inside the wrapper class
+       named by java_outer_classname.  However, the wrapper class will still be
+       generated to contain the file's getDescriptor() method as well as any
+       top-level extensions defined in the file. *)
+      go_package: string option;(** Sets the Go package where structs generated from this .proto will be
+       placed. If omitted, the Go package will be derived from the following:
+         - The basename of the package import path, if provided.
+         - Otherwise, the package statement in the .proto file, if present.
+         - Otherwise, the basename of the .proto file, without extension. *)
+      cc_generic_services: bool;(** Should generic services be generated in each language?  "Generic" services
+       are not specific to any particular RPC system.  They are generated by the
+       main code generators in each language (without additional plugins).
+       Generic services were the only kind of service generation supported by
+       early versions of google.protobuf.
+
+       Generic services are now considered deprecated in favor of using plugins
+       that generate code specific to your particular RPC system.  Therefore,
+       these default to false.  Old code which depends on generic services should
+       explicitly set them to true. *)
+      java_generic_services: bool;
+      py_generic_services: bool;
+      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"];(** This option does nothing.
+      @deprecated deprecated in proto file *)
+      deprecated: bool;(** Is this file deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for everything in the file, or it will be completely ignored; in the very
+       least, this is a formalization for deprecating files. *)
+      java_string_check_utf8: bool;(** If set true, then the Java2 code generator will generate code that
+       throws an exception whenever an attempt is made to assign a non-UTF-8
+       byte sequence to a string field.
+       Message reflection will do the same.
+       However, an extension field still accepts non-UTF-8 byte sequences.
+       This option has no effect on when used with the lite runtime. *)
+      cc_enable_arenas: bool;(** Enables the use of arenas for the proto messages in this file. This applies
+       only to generated classes for C++. *)
+      objc_class_prefix: string option;(** Sets the objective c class prefix which is prepended to all objective c
+       generated classes from this .proto. There is no default. *)
+      csharp_namespace: string option;(** Namespace for generated classes; defaults to the package. *)
+      swift_prefix: string option;(** By default Swift generators will take the proto package and CamelCase it
+       replacing '.' with underscore and use that to prefix the types/symbols
+       defined. When this options is provided, they will use this value instead
+       to prefix the types/symbols defined. *)
+      php_class_prefix: string option;(** Sets the php class prefix which is prepended to all php generated classes
+       from this .proto. Default is empty. *)
+      php_namespace: string option;(** Use this option to change the namespace of php generated classes. Default
+       is empty. When this option is empty, the package name will be used for
+       determining the namespace. *)
+      php_generic_services: bool;
+      php_metadata_namespace: string option;(** Use this option to change the namespace of php generated metadata classes.
+       Default is empty. When this option is empty, the proto file name will be
+       used for determining the namespace. *)
+      ruby_package: string option;(** Use this option to change the package of ruby generated classes. Default
+       is empty. When this option is not set, the package name will be used for
+       determining the ruby package. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here.
+       See the documentation for the "Options" section above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = FileOptions
       module rec OptimizeMode : sig
-        type t = SPEED | CODE_SIZE | LITE_RUNTIME
+        type t =
+          | SPEED
+          (** Generate complete code for parsing, serialization, *)
+          | CODE_SIZE
+          (**
+             etc.
+
+             Use ReflectionOps to implement these methods.
+          *)
+          | LITE_RUNTIME
+          (** Generate code using MessageLite and the lite runtime. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end = struct
-        type t = SPEED | CODE_SIZE | LITE_RUNTIME
+        module This'_ = OptimizeMode
+        type t =
+          | SPEED
+          (** Generate complete code for parsing, serialization, *)
+          | CODE_SIZE
+          (**
+             etc.
+
+             Use ReflectionOps to implement these methods.
+          *)
+          | LITE_RUNTIME
+          (** Generate code using MessageLite and the lite runtime. *)
+
         let name () = ".google.protobuf.FileOptions.OptimizeMode"
         let to_int = function
           | SPEED -> 1
@@ -1767,55 +4604,126 @@ end = struct
 
       end
       let name () = ".google.protobuf.FileOptions"
-      type t = { java_package: string option; java_outer_classname: string option; optimize_for: OptimizeMode.t; java_multiple_files: bool; go_package: string option; cc_generic_services: bool; java_generic_services: bool; py_generic_services: bool; java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"]; deprecated: bool; java_string_check_utf8: bool; cc_enable_arenas: bool; objc_class_prefix: string option; csharp_namespace: string option; swift_prefix: string option; php_class_prefix: string option; php_namespace: string option; php_generic_services: bool; php_metadata_namespace: string option; ruby_package: string option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      java_package: string option;(** Sets the Java package where classes generated from this .proto will be
+       placed.  By default, the proto package is used, but this is often
+       inappropriate because proto packages do not normally start with backwards
+       domain names. *)
+      java_outer_classname: string option;(** Controls the name of the wrapper Java class generated for the .proto file.
+       That class will always contain the .proto file's getDescriptor() method as
+       well as any top-level extensions defined in the .proto file.
+       If java_multiple_files is disabled, then all the other classes from the
+       .proto file will be nested inside the single wrapper outer class. *)
+      optimize_for: OptimizeMode.t;(** Clients can define custom options in extensions of this message.
+       See the documentation for the "Options" section above. *)
+      java_multiple_files: bool;(** If enabled, then the Java code generator will generate a separate .java
+       file for each top-level message, enum, and service defined in the .proto
+       file.  Thus, these types will *not* be nested inside the wrapper class
+       named by java_outer_classname.  However, the wrapper class will still be
+       generated to contain the file's getDescriptor() method as well as any
+       top-level extensions defined in the file. *)
+      go_package: string option;(** Sets the Go package where structs generated from this .proto will be
+       placed. If omitted, the Go package will be derived from the following:
+         - The basename of the package import path, if provided.
+         - Otherwise, the package statement in the .proto file, if present.
+         - Otherwise, the basename of the .proto file, without extension. *)
+      cc_generic_services: bool;(** Should generic services be generated in each language?  "Generic" services
+       are not specific to any particular RPC system.  They are generated by the
+       main code generators in each language (without additional plugins).
+       Generic services were the only kind of service generation supported by
+       early versions of google.protobuf.
+
+       Generic services are now considered deprecated in favor of using plugins
+       that generate code specific to your particular RPC system.  Therefore,
+       these default to false.  Old code which depends on generic services should
+       explicitly set them to true. *)
+      java_generic_services: bool;
+      py_generic_services: bool;
+      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"];(** This option does nothing.
+      @deprecated deprecated in proto file *)
+      deprecated: bool;(** Is this file deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for everything in the file, or it will be completely ignored; in the very
+       least, this is a formalization for deprecating files. *)
+      java_string_check_utf8: bool;(** If set true, then the Java2 code generator will generate code that
+       throws an exception whenever an attempt is made to assign a non-UTF-8
+       byte sequence to a string field.
+       Message reflection will do the same.
+       However, an extension field still accepts non-UTF-8 byte sequences.
+       This option has no effect on when used with the lite runtime. *)
+      cc_enable_arenas: bool;(** Enables the use of arenas for the proto messages in this file. This applies
+       only to generated classes for C++. *)
+      objc_class_prefix: string option;(** Sets the objective c class prefix which is prepended to all objective c
+       generated classes from this .proto. There is no default. *)
+      csharp_namespace: string option;(** Namespace for generated classes; defaults to the package. *)
+      swift_prefix: string option;(** By default Swift generators will take the proto package and CamelCase it
+       replacing '.' with underscore and use that to prefix the types/symbols
+       defined. When this options is provided, they will use this value instead
+       to prefix the types/symbols defined. *)
+      php_class_prefix: string option;(** Sets the php class prefix which is prepended to all php generated classes
+       from this .proto. Default is empty. *)
+      php_namespace: string option;(** Use this option to change the namespace of php generated classes. Default
+       is empty. When this option is empty, the package name will be used for
+       determining the namespace. *)
+      php_generic_services: bool;
+      php_metadata_namespace: string option;(** Use this option to change the namespace of php generated metadata classes.
+       Default is empty. When this option is empty, the proto file name will be
+       used for determining the namespace. *)
+      ruby_package: string option;(** Use this option to change the package of ruby generated classes. Default
+       is empty. When this option is not set, the package name will be used for
+       determining the ruby package. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here.
+       See the documentation for the "Options" section above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?java_package ?java_outer_classname ?(optimize_for = OptimizeMode.SPEED) ?(java_multiple_files = false) ?go_package ?(cc_generic_services = false) ?(java_generic_services = false) ?(py_generic_services = false) ?java_generate_equals_and_hash ?(deprecated = false) ?(java_string_check_utf8 = false) ?(cc_enable_arenas = true) ?objc_class_prefix ?csharp_namespace ?swift_prefix ?php_class_prefix ?php_namespace ?(php_generic_services = false) ?php_metadata_namespace ?ruby_package ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { java_package; java_outer_classname; optimize_for; java_multiple_files; go_package; cc_generic_services; java_generic_services; py_generic_services; java_generate_equals_and_hash; deprecated; java_string_check_utf8; cc_enable_arenas; objc_class_prefix; csharp_namespace; swift_prefix; php_class_prefix; php_namespace; php_generic_services; php_metadata_namespace; ruby_package; uninterpreted_option; extensions' }
       let merge =
-        let merge_java_package = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "java_package", "javaPackage"), string) ) in
-        let merge_java_outer_classname = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((8, "java_outer_classname", "javaOuterClassname"), string) ) in
-        let merge_optimize_for = Runtime'.Merge.merge Runtime'.Spec.( basic ((9, "optimize_for", "optimizeFor"), (enum (module OptimizeMode)), (OptimizeMode.SPEED)) ) in
-        let merge_java_multiple_files = Runtime'.Merge.merge Runtime'.Spec.( basic ((10, "java_multiple_files", "javaMultipleFiles"), bool, (false)) ) in
-        let merge_go_package = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((11, "go_package", "goPackage"), string) ) in
-        let merge_cc_generic_services = Runtime'.Merge.merge Runtime'.Spec.( basic ((16, "cc_generic_services", "ccGenericServices"), bool, (false)) ) in
-        let merge_java_generic_services = Runtime'.Merge.merge Runtime'.Spec.( basic ((17, "java_generic_services", "javaGenericServices"), bool, (false)) ) in
-        let merge_py_generic_services = Runtime'.Merge.merge Runtime'.Spec.( basic ((18, "py_generic_services", "pyGenericServices"), bool, (false)) ) in
-        let merge_java_generate_equals_and_hash = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((20, "java_generate_equals_and_hash", "javaGenerateEqualsAndHash"), bool) ) in
-        let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((23, "deprecated", "deprecated"), bool, (false)) ) in
-        let merge_java_string_check_utf8 = Runtime'.Merge.merge Runtime'.Spec.( basic ((27, "java_string_check_utf8", "javaStringCheckUtf8"), bool, (false)) ) in
-        let merge_cc_enable_arenas = Runtime'.Merge.merge Runtime'.Spec.( basic ((31, "cc_enable_arenas", "ccEnableArenas"), bool, (true)) ) in
-        let merge_objc_class_prefix = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((36, "objc_class_prefix", "objcClassPrefix"), string) ) in
-        let merge_csharp_namespace = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((37, "csharp_namespace", "csharpNamespace"), string) ) in
-        let merge_swift_prefix = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((39, "swift_prefix", "swiftPrefix"), string) ) in
-        let merge_php_class_prefix = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((40, "php_class_prefix", "phpClassPrefix"), string) ) in
-        let merge_php_namespace = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((41, "php_namespace", "phpNamespace"), string) ) in
-        let merge_php_generic_services = Runtime'.Merge.merge Runtime'.Spec.( basic ((42, "php_generic_services", "phpGenericServices"), bool, (false)) ) in
-        let merge_php_metadata_namespace = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((44, "php_metadata_namespace", "phpMetadataNamespace"), string) ) in
-        let merge_ruby_package = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((45, "ruby_package", "rubyPackage"), string) ) in
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          java_package = (merge_java_package t1.java_package t2.java_package);
-          java_outer_classname = (merge_java_outer_classname t1.java_outer_classname t2.java_outer_classname);
-          optimize_for = (merge_optimize_for t1.optimize_for t2.optimize_for);
-          java_multiple_files = (merge_java_multiple_files t1.java_multiple_files t2.java_multiple_files);
-          go_package = (merge_go_package t1.go_package t2.go_package);
-          cc_generic_services = (merge_cc_generic_services t1.cc_generic_services t2.cc_generic_services);
-          java_generic_services = (merge_java_generic_services t1.java_generic_services t2.java_generic_services);
-          py_generic_services = (merge_py_generic_services t1.py_generic_services t2.py_generic_services);
-          java_generate_equals_and_hash = (merge_java_generate_equals_and_hash t1.java_generate_equals_and_hash t2.java_generate_equals_and_hash);
-          deprecated = (merge_deprecated t1.deprecated t2.deprecated);
-          java_string_check_utf8 = (merge_java_string_check_utf8 t1.java_string_check_utf8 t2.java_string_check_utf8);
-          cc_enable_arenas = (merge_cc_enable_arenas t1.cc_enable_arenas t2.cc_enable_arenas);
-          objc_class_prefix = (merge_objc_class_prefix t1.objc_class_prefix t2.objc_class_prefix);
-          csharp_namespace = (merge_csharp_namespace t1.csharp_namespace t2.csharp_namespace);
-          swift_prefix = (merge_swift_prefix t1.swift_prefix t2.swift_prefix);
-          php_class_prefix = (merge_php_class_prefix t1.php_class_prefix t2.php_class_prefix);
-          php_namespace = (merge_php_namespace t1.php_namespace t2.php_namespace);
-          php_generic_services = (merge_php_generic_services t1.php_generic_services t2.php_generic_services);
-          php_metadata_namespace = (merge_php_metadata_namespace t1.php_metadata_namespace t2.php_metadata_namespace);
-          ruby_package = (merge_ruby_package t1.ruby_package t2.ruby_package);
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_java_package = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "java_package", "javaPackage"), string) ) in
+      let merge_java_outer_classname = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((8, "java_outer_classname", "javaOuterClassname"), string) ) in
+      let merge_optimize_for = Runtime'.Merge.merge Runtime'.Spec.( basic ((9, "optimize_for", "optimizeFor"), (enum (module OptimizeMode)), (OptimizeMode.SPEED)) ) in
+      let merge_java_multiple_files = Runtime'.Merge.merge Runtime'.Spec.( basic ((10, "java_multiple_files", "javaMultipleFiles"), bool, (false)) ) in
+      let merge_go_package = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((11, "go_package", "goPackage"), string) ) in
+      let merge_cc_generic_services = Runtime'.Merge.merge Runtime'.Spec.( basic ((16, "cc_generic_services", "ccGenericServices"), bool, (false)) ) in
+      let merge_java_generic_services = Runtime'.Merge.merge Runtime'.Spec.( basic ((17, "java_generic_services", "javaGenericServices"), bool, (false)) ) in
+      let merge_py_generic_services = Runtime'.Merge.merge Runtime'.Spec.( basic ((18, "py_generic_services", "pyGenericServices"), bool, (false)) ) in
+      let merge_java_generate_equals_and_hash = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((20, "java_generate_equals_and_hash", "javaGenerateEqualsAndHash"), bool) ) in
+      let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((23, "deprecated", "deprecated"), bool, (false)) ) in
+      let merge_java_string_check_utf8 = Runtime'.Merge.merge Runtime'.Spec.( basic ((27, "java_string_check_utf8", "javaStringCheckUtf8"), bool, (false)) ) in
+      let merge_cc_enable_arenas = Runtime'.Merge.merge Runtime'.Spec.( basic ((31, "cc_enable_arenas", "ccEnableArenas"), bool, (true)) ) in
+      let merge_objc_class_prefix = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((36, "objc_class_prefix", "objcClassPrefix"), string) ) in
+      let merge_csharp_namespace = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((37, "csharp_namespace", "csharpNamespace"), string) ) in
+      let merge_swift_prefix = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((39, "swift_prefix", "swiftPrefix"), string) ) in
+      let merge_php_class_prefix = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((40, "php_class_prefix", "phpClassPrefix"), string) ) in
+      let merge_php_namespace = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((41, "php_namespace", "phpNamespace"), string) ) in
+      let merge_php_generic_services = Runtime'.Merge.merge Runtime'.Spec.( basic ((42, "php_generic_services", "phpGenericServices"), bool, (false)) ) in
+      let merge_php_metadata_namespace = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((44, "php_metadata_namespace", "phpMetadataNamespace"), string) ) in
+      let merge_ruby_package = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((45, "ruby_package", "rubyPackage"), string) ) in
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      java_package = (merge_java_package t1.java_package t2.java_package);
+      java_outer_classname = (merge_java_outer_classname t1.java_outer_classname t2.java_outer_classname);
+      optimize_for = (merge_optimize_for t1.optimize_for t2.optimize_for);
+      java_multiple_files = (merge_java_multiple_files t1.java_multiple_files t2.java_multiple_files);
+      go_package = (merge_go_package t1.go_package t2.go_package);
+      cc_generic_services = (merge_cc_generic_services t1.cc_generic_services t2.cc_generic_services);
+      java_generic_services = (merge_java_generic_services t1.java_generic_services t2.java_generic_services);
+      py_generic_services = (merge_py_generic_services t1.py_generic_services t2.py_generic_services);
+      java_generate_equals_and_hash = (merge_java_generate_equals_and_hash t1.java_generate_equals_and_hash t2.java_generate_equals_and_hash);
+      deprecated = (merge_deprecated t1.deprecated t2.deprecated);
+      java_string_check_utf8 = (merge_java_string_check_utf8 t1.java_string_check_utf8 t2.java_string_check_utf8);
+      cc_enable_arenas = (merge_cc_enable_arenas t1.cc_enable_arenas t2.cc_enable_arenas);
+      objc_class_prefix = (merge_objc_class_prefix t1.objc_class_prefix t2.objc_class_prefix);
+      csharp_namespace = (merge_csharp_namespace t1.csharp_namespace t2.csharp_namespace);
+      swift_prefix = (merge_swift_prefix t1.swift_prefix t2.swift_prefix);
+      php_class_prefix = (merge_php_class_prefix t1.php_class_prefix t2.php_class_prefix);
+      php_namespace = (merge_php_namespace t1.php_namespace t2.php_namespace);
+      php_generic_services = (merge_php_generic_services t1.php_generic_services t2.php_generic_services);
+      php_metadata_namespace = (merge_php_metadata_namespace t1.php_metadata_namespace t2.php_metadata_namespace);
+      ruby_package = (merge_ruby_package t1.ruby_package t2.ruby_package);
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( basic_opt ((1, "java_package", "javaPackage"), string) ^:: basic_opt ((8, "java_outer_classname", "javaOuterClassname"), string) ^:: basic ((9, "optimize_for", "optimizeFor"), (enum (module OptimizeMode)), (OptimizeMode.SPEED)) ^:: basic ((10, "java_multiple_files", "javaMultipleFiles"), bool, (false)) ^:: basic_opt ((11, "go_package", "goPackage"), string) ^:: basic ((16, "cc_generic_services", "ccGenericServices"), bool, (false)) ^:: basic ((17, "java_generic_services", "javaGenericServices"), bool, (false)) ^:: basic ((18, "py_generic_services", "pyGenericServices"), bool, (false)) ^:: basic_opt ((20, "java_generate_equals_and_hash", "javaGenerateEqualsAndHash"), bool) ^:: basic ((23, "deprecated", "deprecated"), bool, (false)) ^:: basic ((27, "java_string_check_utf8", "javaStringCheckUtf8"), bool, (false)) ^:: basic ((31, "cc_enable_arenas", "ccEnableArenas"), bool, (true)) ^:: basic_opt ((36, "objc_class_prefix", "objcClassPrefix"), string) ^:: basic_opt ((37, "csharp_namespace", "csharpNamespace"), string) ^:: basic_opt ((39, "swift_prefix", "swiftPrefix"), string) ^:: basic_opt ((40, "php_class_prefix", "phpClassPrefix"), string) ^:: basic_opt ((41, "php_namespace", "phpNamespace"), string) ^:: basic ((42, "php_generic_services", "phpGenericServices"), bool, (false)) ^:: basic_opt ((44, "php_metadata_namespace", "phpMetadataNamespace"), string) ^:: basic_opt ((45, "ruby_package", "rubyPackage"), string) ^:: repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1835,37 +4743,150 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and MessageOptions : sig
-      val name: unit -> string
-      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      message_set_wire_format: bool;(** Set true to use the old proto1 MessageSet wire format for extensions.
+       This is provided for backwards-compatibility with the MessageSet wire
+       format.  You should not use this for any other reason:  It's less
+       efficient, has fewer features, and is more complicated.
+
+       The message must be defined exactly as follows:
+         message Foo \{
+           option message_set_wire_format = true;
+           extensions 4 to max;
+         \}
+       Note that the message cannot have any defined fields; MessageSets only
+       have extensions.
+
+       All extensions of your type must be singular messages; e.g. they cannot
+       be int32s, enums, or repeated messages.
+
+       Because this is an option, the above two restrictions are not enforced by
+       the protocol compiler. *)
+      no_standard_descriptor_accessor: bool;(** Disables the generation of the standard "descriptor()" accessor, which can
+       conflict with a field of the same name.  This is meant to make migration
+       from proto1 easier; new code should avoid fields named "descriptor". *)
+      deprecated: bool;(** Is this message deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the message, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating messages. *)
+      map_entry: bool option;(** Whether the message is an automatically generated map entry type for the
+       maps field.
+
+       For maps fields:
+           map<KeyType, ValueType> map_field = 1;
+       The parsed descriptor looks like:
+           message MapFieldEntry \{
+               option map_entry = true;
+               optional KeyType key = 1;
+               optional ValueType value = 2;
+           \}
+           repeated MapFieldEntry map_field = 1;
+
+       Implementations may choose not to generate the map_entry=true message, but
+       use a native map in the target language to hold the keys and values.
+       The reflection APIs in such implementations still need to work as
+       if the field is a repeated message field.
+
+       NOTE: Do not set the option in .proto files. Always use the maps syntax
+       instead. The option should only be implicitly set by the proto compiler
+       parser. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = MessageOptions
       let name () = ".google.protobuf.MessageOptions"
-      type t = { message_set_wire_format: bool; no_standard_descriptor_accessor: bool; deprecated: bool; map_entry: bool option; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      message_set_wire_format: bool;(** Set true to use the old proto1 MessageSet wire format for extensions.
+       This is provided for backwards-compatibility with the MessageSet wire
+       format.  You should not use this for any other reason:  It's less
+       efficient, has fewer features, and is more complicated.
+
+       The message must be defined exactly as follows:
+         message Foo \{
+           option message_set_wire_format = true;
+           extensions 4 to max;
+         \}
+       Note that the message cannot have any defined fields; MessageSets only
+       have extensions.
+
+       All extensions of your type must be singular messages; e.g. they cannot
+       be int32s, enums, or repeated messages.
+
+       Because this is an option, the above two restrictions are not enforced by
+       the protocol compiler. *)
+      no_standard_descriptor_accessor: bool;(** Disables the generation of the standard "descriptor()" accessor, which can
+       conflict with a field of the same name.  This is meant to make migration
+       from proto1 easier; new code should avoid fields named "descriptor". *)
+      deprecated: bool;(** Is this message deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the message, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating messages. *)
+      map_entry: bool option;(** Whether the message is an automatically generated map entry type for the
+       maps field.
+
+       For maps fields:
+           map<KeyType, ValueType> map_field = 1;
+       The parsed descriptor looks like:
+           message MapFieldEntry \{
+               option map_entry = true;
+               optional KeyType key = 1;
+               optional ValueType value = 2;
+           \}
+           repeated MapFieldEntry map_field = 1;
+
+       Implementations may choose not to generate the map_entry=true message, but
+       use a native map in the target language to hold the keys and values.
+       The reflection APIs in such implementations still need to work as
+       if the field is a repeated message field.
+
+       NOTE: Do not set the option in .proto files. Always use the maps syntax
+       instead. The option should only be implicitly set by the proto compiler
+       parser. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?message_set_wire_format:bool -> ?no_standard_descriptor_accessor:bool -> ?deprecated:bool -> ?map_entry:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?(message_set_wire_format = false) ?(no_standard_descriptor_accessor = false) ?(deprecated = false) ?map_entry ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { message_set_wire_format; no_standard_descriptor_accessor; deprecated; map_entry; uninterpreted_option; extensions' }
       let merge =
-        let merge_message_set_wire_format = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "message_set_wire_format", "messageSetWireFormat"), bool, (false)) ) in
-        let merge_no_standard_descriptor_accessor = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "no_standard_descriptor_accessor", "noStandardDescriptorAccessor"), bool, (false)) ) in
-        let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "deprecated", "deprecated"), bool, (false)) ) in
-        let merge_map_entry = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((7, "map_entry", "mapEntry"), bool) ) in
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          message_set_wire_format = (merge_message_set_wire_format t1.message_set_wire_format t2.message_set_wire_format);
-          no_standard_descriptor_accessor = (merge_no_standard_descriptor_accessor t1.no_standard_descriptor_accessor t2.no_standard_descriptor_accessor);
-          deprecated = (merge_deprecated t1.deprecated t2.deprecated);
-          map_entry = (merge_map_entry t1.map_entry t2.map_entry);
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_message_set_wire_format = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "message_set_wire_format", "messageSetWireFormat"), bool, (false)) ) in
+      let merge_no_standard_descriptor_accessor = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "no_standard_descriptor_accessor", "noStandardDescriptorAccessor"), bool, (false)) ) in
+      let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "deprecated", "deprecated"), bool, (false)) ) in
+      let merge_map_entry = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((7, "map_entry", "mapEntry"), bool) ) in
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      message_set_wire_format = (merge_message_set_wire_format t1.message_set_wire_format t2.message_set_wire_format);
+      no_standard_descriptor_accessor = (merge_no_standard_descriptor_accessor t1.no_standard_descriptor_accessor t2.no_standard_descriptor_accessor);
+      deprecated = (merge_deprecated t1.deprecated t2.deprecated);
+      map_entry = (merge_map_entry t1.map_entry t2.map_entry);
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( basic ((1, "message_set_wire_format", "messageSetWireFormat"), bool, (false)) ^:: basic ((2, "no_standard_descriptor_accessor", "noStandardDescriptorAccessor"), bool, (false)) ^:: basic ((3, "deprecated", "deprecated"), bool, (false)) ^:: basic_opt ((7, "map_entry", "mapEntry"), bool) ^:: repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -1886,46 +4907,158 @@ end = struct
     end
     and FieldOptions : sig
       module rec CType : sig
-        type t = STRING | CORD | STRING_PIECE
+        type t =
+          | STRING
+          (** Default mode. *)
+          | CORD
+          | STRING_PIECE
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
       and JSType : sig
-        type t = JS_NORMAL | JS_STRING | JS_NUMBER
+        type t =
+          | JS_NORMAL
+          (** Use the default type. *)
+          | JS_STRING
+          (** Use JavaScript strings. *)
+          | JS_NUMBER
+          (** Use JavaScript numbers. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      ctype: CType.t;(** The ctype option instructs the C++ code generator to use a different
+       representation of the field than it normally would.  See the specific
+       options below.  This option is not yet implemented in the open source
+       release -- sorry, we'll try to include it in a future version! *)
+      packed: bool option;(** The packed option can be enabled for repeated primitive fields to enable
+       a more efficient representation on the wire. Rather than repeatedly
+       writing the tag and type for each element, the entire array is encoded as
+       a single length-delimited blob. In proto3, only explicit setting it to
+       false will avoid using packed encoding. *)
+      deprecated: bool;(** Clients can define custom options in extensions of this message. See above. *)
+      lazy': bool;(** Should this field be parsed lazily?  Lazy applies only to message-type
+       fields.  It means that when the outer message is initially parsed, the
+       inner message's contents will not be parsed but instead stored in encoded
+       form.  The inner message will actually be parsed when it is first accessed.
+
+       This is only a hint.  Implementations are free to choose whether to use
+       eager or lazy parsing regardless of the value of this option.  However,
+       setting this option true suggests that the protocol author believes that
+       using lazy parsing on this field is worth the additional bookkeeping
+       overhead typically needed to implement it.
+
+       This option does not affect the public interface of any generated code;
+       all method signatures remain the same.  Furthermore, thread-safety of the
+       interface is not affected by this option; const methods remain safe to
+       call from multiple threads concurrently, while non-const methods continue
+       to require exclusive access.
+
+
+       Note that implementations may choose not to check required fields within
+       a lazy sub-message.  That is, calling IsInitialized() on the outer message
+       may return true even if the inner message has missing required fields.
+       This is necessary because otherwise the inner message would have to be
+       parsed in order to perform the check, defeating the purpose of lazy
+       parsing.  An implementation which chooses not to check required fields
+       must be consistent about it.  That is, for any particular sub-message, the
+       implementation must either *always* check its required fields, or *never*
+       check its required fields, regardless of whether or not the message has
+       been parsed.
+
+       As of 2021, lazy does no correctness checks on the byte stream during
+       parsing.  This may lead to crashes if and when an invalid byte stream is
+       finally parsed upon access.
+
+       TODO(b/211906113):  Enable validation on lazy fields. *)
+      jstype: JSType.t;(** The jstype option determines the JavaScript type used for values of the
+       field.  The option is permitted only for 64 bit integral and fixed types
+       (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+       is represented as JavaScript string, which avoids loss of precision that
+       can happen when a large value is converted to a floating point JavaScript.
+       Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+       use the JavaScript "number" type.  The behavior of the default option
+       JS_NORMAL is implementation dependent.
+
+       This option is an enum to permit additional types to be added, e.g.
+       goog.math.Integer. *)
+      weak: bool;(** For Google-internal migration only. Do not use. *)
+      unverified_lazy: bool;(** unverified_lazy does no correctness checks on the byte stream. This should
+       only be used where lazy with verification is prohibitive for performance
+       reasons. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = FieldOptions
       module rec CType : sig
-        type t = STRING | CORD | STRING_PIECE
+        type t =
+          | STRING
+          (** Default mode. *)
+          | CORD
+          | STRING_PIECE
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end = struct
-        type t = STRING | CORD | STRING_PIECE
+        module This'_ = CType
+        type t =
+          | STRING
+          (** Default mode. *)
+          | CORD
+          | STRING_PIECE
+
         let name () = ".google.protobuf.FieldOptions.CType"
         let to_int = function
           | STRING -> 0
@@ -1949,15 +5082,34 @@ end = struct
 
       end
       and JSType : sig
-        type t = JS_NORMAL | JS_STRING | JS_NUMBER
+        type t =
+          | JS_NORMAL
+          (** Use the default type. *)
+          | JS_STRING
+          (** Use JavaScript strings. *)
+          | JS_NUMBER
+          (** Use JavaScript numbers. *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end = struct
-        type t = JS_NORMAL | JS_STRING | JS_NUMBER
+        module This'_ = JSType
+        type t =
+          | JS_NORMAL
+          (** Use the default type. *)
+          | JS_STRING
+          (** Use JavaScript strings. *)
+          | JS_NUMBER
+          (** Use JavaScript numbers. *)
+
         let name () = ".google.protobuf.FieldOptions.JSType"
         let to_int = function
           | JS_NORMAL -> 0
@@ -1981,29 +5133,91 @@ end = struct
 
       end
       let name () = ".google.protobuf.FieldOptions"
-      type t = { ctype: CType.t; packed: bool option; deprecated: bool; lazy': bool; jstype: JSType.t; weak: bool; unverified_lazy: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      ctype: CType.t;(** The ctype option instructs the C++ code generator to use a different
+       representation of the field than it normally would.  See the specific
+       options below.  This option is not yet implemented in the open source
+       release -- sorry, we'll try to include it in a future version! *)
+      packed: bool option;(** The packed option can be enabled for repeated primitive fields to enable
+       a more efficient representation on the wire. Rather than repeatedly
+       writing the tag and type for each element, the entire array is encoded as
+       a single length-delimited blob. In proto3, only explicit setting it to
+       false will avoid using packed encoding. *)
+      deprecated: bool;(** Clients can define custom options in extensions of this message. See above. *)
+      lazy': bool;(** Should this field be parsed lazily?  Lazy applies only to message-type
+       fields.  It means that when the outer message is initially parsed, the
+       inner message's contents will not be parsed but instead stored in encoded
+       form.  The inner message will actually be parsed when it is first accessed.
+
+       This is only a hint.  Implementations are free to choose whether to use
+       eager or lazy parsing regardless of the value of this option.  However,
+       setting this option true suggests that the protocol author believes that
+       using lazy parsing on this field is worth the additional bookkeeping
+       overhead typically needed to implement it.
+
+       This option does not affect the public interface of any generated code;
+       all method signatures remain the same.  Furthermore, thread-safety of the
+       interface is not affected by this option; const methods remain safe to
+       call from multiple threads concurrently, while non-const methods continue
+       to require exclusive access.
+
+
+       Note that implementations may choose not to check required fields within
+       a lazy sub-message.  That is, calling IsInitialized() on the outer message
+       may return true even if the inner message has missing required fields.
+       This is necessary because otherwise the inner message would have to be
+       parsed in order to perform the check, defeating the purpose of lazy
+       parsing.  An implementation which chooses not to check required fields
+       must be consistent about it.  That is, for any particular sub-message, the
+       implementation must either *always* check its required fields, or *never*
+       check its required fields, regardless of whether or not the message has
+       been parsed.
+
+       As of 2021, lazy does no correctness checks on the byte stream during
+       parsing.  This may lead to crashes if and when an invalid byte stream is
+       finally parsed upon access.
+
+       TODO(b/211906113):  Enable validation on lazy fields. *)
+      jstype: JSType.t;(** The jstype option determines the JavaScript type used for values of the
+       field.  The option is permitted only for 64 bit integral and fixed types
+       (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+       is represented as JavaScript string, which avoids loss of precision that
+       can happen when a large value is converted to a floating point JavaScript.
+       Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+       use the JavaScript "number" type.  The behavior of the default option
+       JS_NORMAL is implementation dependent.
+
+       This option is an enum to permit additional types to be added, e.g.
+       goog.math.Integer. *)
+      weak: bool;(** For Google-internal migration only. Do not use. *)
+      unverified_lazy: bool;(** unverified_lazy does no correctness checks on the byte stream. This should
+       only be used where lazy with verification is prohibitive for performance
+       reasons. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?ctype:CType.t -> ?packed:bool -> ?deprecated:bool -> ?lazy':bool -> ?jstype:JSType.t -> ?weak:bool -> ?unverified_lazy:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?(ctype = CType.STRING) ?packed ?(deprecated = false) ?(lazy' = false) ?(jstype = JSType.JS_NORMAL) ?(weak = false) ?(unverified_lazy = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { ctype; packed; deprecated; lazy'; jstype; weak; unverified_lazy; uninterpreted_option; extensions' }
       let merge =
-        let merge_ctype = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "ctype", "ctype"), (enum (module CType)), (CType.STRING)) ) in
-        let merge_packed = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "packed", "packed"), bool) ) in
-        let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "deprecated", "deprecated"), bool, (false)) ) in
-        let merge_lazy' = Runtime'.Merge.merge Runtime'.Spec.( basic ((5, "lazy", "lazy"), bool, (false)) ) in
-        let merge_jstype = Runtime'.Merge.merge Runtime'.Spec.( basic ((6, "jstype", "jstype"), (enum (module JSType)), (JSType.JS_NORMAL)) ) in
-        let merge_weak = Runtime'.Merge.merge Runtime'.Spec.( basic ((10, "weak", "weak"), bool, (false)) ) in
-        let merge_unverified_lazy = Runtime'.Merge.merge Runtime'.Spec.( basic ((15, "unverified_lazy", "unverifiedLazy"), bool, (false)) ) in
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          ctype = (merge_ctype t1.ctype t2.ctype);
-          packed = (merge_packed t1.packed t2.packed);
-          deprecated = (merge_deprecated t1.deprecated t2.deprecated);
-          lazy' = (merge_lazy' t1.lazy' t2.lazy');
-          jstype = (merge_jstype t1.jstype t2.jstype);
-          weak = (merge_weak t1.weak t2.weak);
-          unverified_lazy = (merge_unverified_lazy t1.unverified_lazy t2.unverified_lazy);
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_ctype = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "ctype", "ctype"), (enum (module CType)), (CType.STRING)) ) in
+      let merge_packed = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "packed", "packed"), bool) ) in
+      let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "deprecated", "deprecated"), bool, (false)) ) in
+      let merge_lazy' = Runtime'.Merge.merge Runtime'.Spec.( basic ((5, "lazy", "lazy"), bool, (false)) ) in
+      let merge_jstype = Runtime'.Merge.merge Runtime'.Spec.( basic ((6, "jstype", "jstype"), (enum (module JSType)), (JSType.JS_NORMAL)) ) in
+      let merge_weak = Runtime'.Merge.merge Runtime'.Spec.( basic ((10, "weak", "weak"), bool, (false)) ) in
+      let merge_unverified_lazy = Runtime'.Merge.merge Runtime'.Spec.( basic ((15, "unverified_lazy", "unverifiedLazy"), bool, (false)) ) in
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      ctype = (merge_ctype t1.ctype t2.ctype);
+      packed = (merge_packed t1.packed t2.packed);
+      deprecated = (merge_deprecated t1.deprecated t2.deprecated);
+      lazy' = (merge_lazy' t1.lazy' t2.lazy');
+      jstype = (merge_jstype t1.jstype t2.jstype);
+      weak = (merge_weak t1.weak t2.weak);
+      unverified_lazy = (merge_unverified_lazy t1.unverified_lazy t2.unverified_lazy);
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( basic ((1, "ctype", "ctype"), (enum (module CType)), (CType.STRING)) ^:: basic_opt ((2, "packed", "packed"), bool) ^:: basic ((3, "deprecated", "deprecated"), bool, (false)) ^:: basic ((5, "lazy", "lazy"), bool, (false)) ^:: basic ((6, "jstype", "jstype"), (enum (module JSType)), (JSType.JS_NORMAL)) ^:: basic ((10, "weak", "weak"), bool, (false)) ^:: basic ((15, "unverified_lazy", "unverifiedLazy"), bool, (false)) ^:: repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2023,29 +5237,50 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and OneofOptions : sig
-      val name: unit -> string
-      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = OneofOptions
       let name () = ".google.protobuf.OneofOptions"
-      type t = { uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { uninterpreted_option; extensions' }
       let merge =
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2065,33 +5300,66 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and EnumOptions : sig
-      val name: unit -> string
-      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      allow_alias: bool option;(** Set this option to true to allow mapping different tag names to the same
+       value. *)
+      deprecated: bool;(** Is this enum deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the enum, or it will be completely ignored; in the very least, this
+       is a formalization for deprecating enums. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = EnumOptions
       let name () = ".google.protobuf.EnumOptions"
-      type t = { allow_alias: bool option; deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      allow_alias: bool option;(** Set this option to true to allow mapping different tag names to the same
+       value. *)
+      deprecated: bool;(** Is this enum deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the enum, or it will be completely ignored; in the very least, this
+       is a formalization for deprecating enums. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?allow_alias:bool -> ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?allow_alias ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { allow_alias; deprecated; uninterpreted_option; extensions' }
       let merge =
-        let merge_allow_alias = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "allow_alias", "allowAlias"), bool) ) in
-        let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "deprecated", "deprecated"), bool, (false)) ) in
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          allow_alias = (merge_allow_alias t1.allow_alias t2.allow_alias);
-          deprecated = (merge_deprecated t1.deprecated t2.deprecated);
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_allow_alias = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "allow_alias", "allowAlias"), bool) ) in
+      let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "deprecated", "deprecated"), bool, (false)) ) in
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      allow_alias = (merge_allow_alias t1.allow_alias t2.allow_alias);
+      deprecated = (merge_deprecated t1.deprecated t2.deprecated);
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( basic_opt ((2, "allow_alias", "allowAlias"), bool) ^:: basic ((3, "deprecated", "deprecated"), bool, (false)) ^:: repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2111,31 +5379,60 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and EnumValueOptions : sig
-      val name: unit -> string
-      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this enum value deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the enum value, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating enum values. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = EnumValueOptions
       let name () = ".google.protobuf.EnumValueOptions"
-      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this enum value deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the enum value, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating enum values. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
       let merge =
-        let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "deprecated", "deprecated"), bool, (false)) ) in
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          deprecated = (merge_deprecated t1.deprecated t2.deprecated);
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "deprecated", "deprecated"), bool, (false)) ) in
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      deprecated = (merge_deprecated t1.deprecated t2.deprecated);
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( basic ((1, "deprecated", "deprecated"), bool, (false)) ^:: repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2155,31 +5452,60 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and ServiceOptions : sig
-      val name: unit -> string
-      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this service deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the service, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating services. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = ServiceOptions
       let name () = ".google.protobuf.ServiceOptions"
-      type t = { deprecated: bool; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this service deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the service, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating services. *)
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?(deprecated = false) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; uninterpreted_option; extensions' }
       let merge =
-        let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((33, "deprecated", "deprecated"), bool, (false)) ) in
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          deprecated = (merge_deprecated t1.deprecated t2.deprecated);
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((33, "deprecated", "deprecated"), bool, (false)) ) in
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      deprecated = (merge_deprecated t1.deprecated t2.deprecated);
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( basic ((33, "deprecated", "deprecated"), bool, (false)) ^:: repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2199,38 +5525,94 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and MethodOptions : sig
+
+      (**
+         Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+         or neither? HTTP based RPC implementation may choose GET verb for safe
+         methods, and PUT verb for idempotent methods instead of the default POST.
+      *)
       module rec IdempotencyLevel : sig
-        type t = IDEMPOTENCY_UNKNOWN | NO_SIDE_EFFECTS | IDEMPOTENT
+        type t =
+          | IDEMPOTENCY_UNKNOWN
+          | NO_SIDE_EFFECTS
+          (** implies idempotent *)
+          | IDEMPOTENT
+          (** idempotent, but may have side effects *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end
-      val name: unit -> string
-      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this method deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the method, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating methods. *)
+      idempotency_level: IdempotencyLevel.t;
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = MethodOptions
       module rec IdempotencyLevel : sig
-        type t = IDEMPOTENCY_UNKNOWN | NO_SIDE_EFFECTS | IDEMPOTENT
+        type t =
+          | IDEMPOTENCY_UNKNOWN
+          | NO_SIDE_EFFECTS
+          (** implies idempotent *)
+          | IDEMPOTENT
+          (** idempotent, but may have side effects *)
+
         val name: unit -> string
+        (** Fully qualified protobuf name of this enum *)
+
+        (**/**)
         val to_int: t -> int
         val from_int: int -> t Runtime'.Result.t
         val from_int_exn: int -> t
         val to_string: t -> string
         val from_string_exn: string -> t
+        (**/**)
       end = struct
-        type t = IDEMPOTENCY_UNKNOWN | NO_SIDE_EFFECTS | IDEMPOTENT
+        module This'_ = IdempotencyLevel
+        type t =
+          | IDEMPOTENCY_UNKNOWN
+          | NO_SIDE_EFFECTS
+          (** implies idempotent *)
+          | IDEMPOTENT
+          (** idempotent, but may have side effects *)
+
         let name () = ".google.protobuf.MethodOptions.IdempotencyLevel"
         let to_int = function
           | IDEMPOTENCY_UNKNOWN -> 0
@@ -2254,19 +5636,27 @@ end = struct
 
       end
       let name () = ".google.protobuf.MethodOptions"
-      type t = { deprecated: bool; idempotency_level: IdempotencyLevel.t; uninterpreted_option: UninterpretedOption.t list; extensions': Runtime'.Extensions.t }
+      type t = {
+      deprecated: bool;(** Is this method deprecated?
+       Depending on the target platform, this can emit Deprecated annotations
+       for the method, or it will be completely ignored; in the very least,
+       this is a formalization for deprecating methods. *)
+      idempotency_level: IdempotencyLevel.t;
+      uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
+      extensions': Runtime'.Extensions.t;
+      }
       type make_t = ?deprecated:bool -> ?idempotency_level:IdempotencyLevel.t -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
       let make ?(deprecated = false) ?(idempotency_level = IdempotencyLevel.IDEMPOTENCY_UNKNOWN) ?(uninterpreted_option = []) ?(extensions' = Runtime'.Extensions.default) () = { deprecated; idempotency_level; uninterpreted_option; extensions' }
       let merge =
-        let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((33, "deprecated", "deprecated"), bool, (false)) ) in
-        let merge_idempotency_level = Runtime'.Merge.merge Runtime'.Spec.( basic ((34, "idempotency_level", "idempotencyLevel"), (enum (module IdempotencyLevel)), (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ) in
-        let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
-        fun t1 t2 -> {
-          deprecated = (merge_deprecated t1.deprecated t2.deprecated);
-          idempotency_level = (merge_idempotency_level t1.idempotency_level t2.idempotency_level);
-          uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
-          extensions' = (List.append t1.extensions' t2.extensions');
-         }
+      let merge_deprecated = Runtime'.Merge.merge Runtime'.Spec.( basic ((33, "deprecated", "deprecated"), bool, (false)) ) in
+      let merge_idempotency_level = Runtime'.Merge.merge Runtime'.Spec.( basic ((34, "idempotency_level", "idempotencyLevel"), (enum (module IdempotencyLevel)), (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ) in
+      let merge_uninterpreted_option = Runtime'.Merge.merge Runtime'.Spec.( repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ) in
+      fun t1 t2 -> {
+      deprecated = (merge_deprecated t1.deprecated t2.deprecated);
+      idempotency_level = (merge_idempotency_level t1.idempotency_level t2.idempotency_level);
+      uninterpreted_option = (merge_uninterpreted_option t1.uninterpreted_option t2.uninterpreted_option);
+      extensions' = (List.append t1.extensions' t2.extensions');
+       }
       let spec () = Runtime'.Spec.( basic ((33, "deprecated", "deprecated"), bool, (false)) ^:: basic ((34, "idempotency_level", "idempotencyLevel"), (enum (module IdempotencyLevel)), (IdempotencyLevel.IDEMPOTENCY_UNKNOWN)) ^:: repeated ((999, "uninterpreted_option", "uninterpretedOption"), (message (module UninterpretedOption)), not_packed) ^:: nil_ext [ (1000, 536870912) ] )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2286,58 +5676,128 @@ end = struct
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
     and UninterpretedOption : sig
+
+      (**
+         The name of the uninterpreted option.  Each string represents a segment in
+         a dot-separated name.  is_extension is true iff a segment represents an
+         extension (denoted with parentheses in options specs in .proto files).
+         E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
+         "foo.(bar.baz).moo".
+      *)
       module rec NamePart : sig
-        val name: unit -> string
-        type t = { name_part: string; is_extension: bool }
+        type t = {
+        name_part: string;
+        is_extension: bool;
+        }
         type make_t = name_part:string -> is_extension:bool -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
-      type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
+      type t = {
+      name: NamePart.t list;
+      identifier_value: string option;(** The value of the uninterpreted option, in whatever type the tokenizer
+       identified it as during parsing. Exactly one of these should be set. *)
+      positive_int_value: int option;
+      negative_int_value: int option;
+      double_value: float option;
+      string_value: bytes option;
+      aggregate_value: string option;
+      }
       type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = UninterpretedOption
       module rec NamePart : sig
-        val name: unit -> string
-        type t = { name_part: string; is_extension: bool }
+        type t = {
+        name_part: string;
+        is_extension: bool;
+        }
         type make_t = name_part:string -> is_extension:bool -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = NamePart
         let name () = ".google.protobuf.UninterpretedOption.NamePart"
-        type t = { name_part: string; is_extension: bool }
+        type t = {
+        name_part: string;
+        is_extension: bool;
+        }
         type make_t = name_part:string -> is_extension:bool -> unit -> t
         let make ~name_part ~is_extension () = { name_part; is_extension }
         let merge =
-          let merge_name_part = Runtime'.Merge.merge Runtime'.Spec.( basic_req ((1, "name_part", "namePart"), string) ) in
-          let merge_is_extension = Runtime'.Merge.merge Runtime'.Spec.( basic_req ((2, "is_extension", "isExtension"), bool) ) in
-          fun t1 t2 -> {
-            name_part = (merge_name_part t1.name_part t2.name_part);
-            is_extension = (merge_is_extension t1.is_extension t2.is_extension);
-           }
+        let merge_name_part = Runtime'.Merge.merge Runtime'.Spec.( basic_req ((1, "name_part", "namePart"), string) ) in
+        let merge_is_extension = Runtime'.Merge.merge Runtime'.Spec.( basic_req ((2, "is_extension", "isExtension"), bool) ) in
+        fun t1 t2 -> {
+        name_part = (merge_name_part t1.name_part t2.name_part);
+        is_extension = (merge_is_extension t1.is_extension t2.is_extension);
+         }
         let spec () = Runtime'.Spec.( basic_req ((1, "name_part", "namePart"), string) ^:: basic_req ((2, "is_extension", "isExtension"), bool) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2357,26 +5817,35 @@ end = struct
         let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
       end
       let name () = ".google.protobuf.UninterpretedOption"
-      type t = { name: NamePart.t list; identifier_value: string option; positive_int_value: int option; negative_int_value: int option; double_value: float option; string_value: bytes option; aggregate_value: string option }
+      type t = {
+      name: NamePart.t list;
+      identifier_value: string option;(** The value of the uninterpreted option, in whatever type the tokenizer
+       identified it as during parsing. Exactly one of these should be set. *)
+      positive_int_value: int option;
+      negative_int_value: int option;
+      double_value: float option;
+      string_value: bytes option;
+      aggregate_value: string option;
+      }
       type make_t = ?name:NamePart.t list -> ?identifier_value:string -> ?positive_int_value:int -> ?negative_int_value:int -> ?double_value:float -> ?string_value:bytes -> ?aggregate_value:string -> unit -> t
       let make ?(name = []) ?identifier_value ?positive_int_value ?negative_int_value ?double_value ?string_value ?aggregate_value () = { name; identifier_value; positive_int_value; negative_int_value; double_value; string_value; aggregate_value }
       let merge =
-        let merge_name = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "name", "name"), (message (module NamePart)), not_packed) ) in
-        let merge_identifier_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "identifier_value", "identifierValue"), string) ) in
-        let merge_positive_int_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "positive_int_value", "positiveIntValue"), uint64_int) ) in
-        let merge_negative_int_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((5, "negative_int_value", "negativeIntValue"), int64_int) ) in
-        let merge_double_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((6, "double_value", "doubleValue"), double) ) in
-        let merge_string_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((7, "string_value", "stringValue"), bytes) ) in
-        let merge_aggregate_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((8, "aggregate_value", "aggregateValue"), string) ) in
-        fun t1 t2 -> {
-          name = (merge_name t1.name t2.name);
-          identifier_value = (merge_identifier_value t1.identifier_value t2.identifier_value);
-          positive_int_value = (merge_positive_int_value t1.positive_int_value t2.positive_int_value);
-          negative_int_value = (merge_negative_int_value t1.negative_int_value t2.negative_int_value);
-          double_value = (merge_double_value t1.double_value t2.double_value);
-          string_value = (merge_string_value t1.string_value t2.string_value);
-          aggregate_value = (merge_aggregate_value t1.aggregate_value t2.aggregate_value);
-         }
+      let merge_name = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "name", "name"), (message (module NamePart)), not_packed) ) in
+      let merge_identifier_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "identifier_value", "identifierValue"), string) ) in
+      let merge_positive_int_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "positive_int_value", "positiveIntValue"), uint64_int) ) in
+      let merge_negative_int_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((5, "negative_int_value", "negativeIntValue"), int64_int) ) in
+      let merge_double_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((6, "double_value", "doubleValue"), double) ) in
+      let merge_string_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((7, "string_value", "stringValue"), bytes) ) in
+      let merge_aggregate_value = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((8, "aggregate_value", "aggregateValue"), string) ) in
+      fun t1 t2 -> {
+      name = (merge_name t1.name t2.name);
+      identifier_value = (merge_identifier_value t1.identifier_value t2.identifier_value);
+      positive_int_value = (merge_positive_int_value t1.positive_int_value t2.positive_int_value);
+      negative_int_value = (merge_negative_int_value t1.negative_int_value t2.negative_int_value);
+      double_value = (merge_double_value t1.double_value t2.double_value);
+      string_value = (merge_string_value t1.string_value t2.string_value);
+      aggregate_value = (merge_aggregate_value t1.aggregate_value t2.aggregate_value);
+       }
       let spec () = Runtime'.Spec.( repeated ((2, "name", "name"), (message (module NamePart)), not_packed) ^:: basic_opt ((3, "identifier_value", "identifierValue"), string) ^:: basic_opt ((4, "positive_int_value", "positiveIntValue"), uint64_int) ^:: basic_opt ((5, "negative_int_value", "negativeIntValue"), int64_int) ^:: basic_opt ((6, "double_value", "doubleValue"), double) ^:: basic_opt ((7, "string_value", "stringValue"), bytes) ^:: basic_opt ((8, "aggregate_value", "aggregateValue"), string) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2397,63 +5866,387 @@ end = struct
     end
     and SourceCodeInfo : sig
       module rec Location : sig
-        val name: unit -> string
-        type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
+        type t = {
+        path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
+         location.
+
+         Each element is a field number or an index.  They form a path from
+         the root FileDescriptorProto to the place where the definition occurs.
+         For example, this path:
+           \[ 4, 3, 2, 7, 1 \]
+         refers to:
+           file.message_type(3)  // 4, 3
+               .field(7)         // 2, 7
+               .name()           // 1
+         This is because FileDescriptorProto.message_type has field number 4:
+           repeated DescriptorProto message_type = 4;
+         and DescriptorProto.field has field number 2:
+           repeated FieldDescriptorProto field = 2;
+         and FieldDescriptorProto.name has field number 1:
+           optional string name = 1;
+
+         Thus, the above path gives the location of a field name.  If we removed
+         the last element:
+           \[ 4, 3, 2, 7 \]
+         this path refers to the whole field declaration (from the beginning
+         of the label to the terminating semicolon). *)
+        span: int list;(** Always has exactly three or four elements: start line, start column,
+         end line (optional, otherwise assumed same as start line), end column.
+         These are packed into a single field for efficiency.  Note that line
+         and column numbers are zero-based -- typically you will want to add
+         1 to each before displaying to a user. *)
+        leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
+         comments appearing before and after the declaration which appear to be
+         attached to the declaration.
+
+         A series of line comments appearing on consecutive lines, with no other
+         tokens appearing on those lines, will be treated as a single comment.
+
+         leading_detached_comments will keep paragraphs of comments that appear
+         before (but not connected to) the current element. Each paragraph,
+         separated by empty lines, will be one comment element in the repeated
+         field.
+
+         Only the comment content is provided; comment markers (e.g. //) are
+         stripped out.  For block comments, leading whitespace and an asterisk
+         will be stripped from the beginning of each line other than the first.
+         Newlines are included in the output.
+
+         Examples:
+
+           optional int32 foo = 1;  // Comment attached to foo.
+           // Comment attached to bar.
+           optional int32 bar = 2;
+
+           optional string baz = 3;
+           // Comment attached to baz.
+           // Another line attached to baz.
+
+           // Comment attached to moo.
+           //
+           // Another line attached to moo.
+           optional double moo = 4;
+
+           // Detached comment for corge. This is not leading or trailing comments
+           // to moo or corge because there are blank lines separating it from
+           // both.
+
+           // Detached comment for corge paragraph 2.
+
+           optional string corge = 5;
+           /* Block comment attached
+            * to corge.  Leading asterisks
+            * will be removed. */
+           /* Block comment attached to
+            * grault. */
+           optional int32 grault = 6;
+
+           // ignored detached comments. *)
+        trailing_comments: string option;
+        leading_detached_comments: string list;
+        }
         type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
       type t = (Location.t list)
+      (**
+      @param location A Location identifies a piece of source code in a .proto file which
+       corresponds to a particular definition.  This information is intended
+       to be useful to IDEs, code indexers, documentation generators, and similar
+       tools.
+
+       For example, say we have a file like:
+         message Foo \{
+           optional string foo = 1;
+         \}
+       Let's look at just the field definition:
+         optional string foo = 1;
+         ^       ^^     ^^  ^  ^^^
+         a       bc     de  f  ghi
+       We have the following locations:
+         span   path               represents
+         \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
+         \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
+         \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
+         \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
+         \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
+
+       Notes:
+       - A location may refer to a repeated field itself (i.e. not to any
+         particular index within it).  This is used whenever a set of elements are
+         logically enclosed in a single code segment.  For example, an entire
+         extend block (possibly containing multiple extension definitions) will
+         have an outer location whose path refers to the "extensions" repeated
+         field without an index.
+       - Multiple locations may have the same path.  This happens when a single
+         logical declaration is spread out across multiple places.  The most
+         obvious example is the "extend" block again -- there may be multiple
+         extend blocks in the same scope, each of which will have the same path.
+       - A location's span is not always a subset of its parent's span.  For
+         example, the "extendee" of an extension declaration appears at the
+         beginning of the "extend" block and is shared by all extensions within
+         the block.
+       - Just because a location's span is a subset of some other location's span
+         does not mean that it is a descendant.  For example, a "group" defines
+         both a type and a field in a single declaration.  Thus, the locations
+         corresponding to the type and field and their components will overlap.
+       - Code which tries to interpret locations should probably be designed to
+         ignore those that it doesn't understand, as more types of locations could
+         be recorded in the future.
+      *)
+
       type make_t = ?location:Location.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = SourceCodeInfo
       module rec Location : sig
-        val name: unit -> string
-        type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
+        type t = {
+        path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
+         location.
+
+         Each element is a field number or an index.  They form a path from
+         the root FileDescriptorProto to the place where the definition occurs.
+         For example, this path:
+           \[ 4, 3, 2, 7, 1 \]
+         refers to:
+           file.message_type(3)  // 4, 3
+               .field(7)         // 2, 7
+               .name()           // 1
+         This is because FileDescriptorProto.message_type has field number 4:
+           repeated DescriptorProto message_type = 4;
+         and DescriptorProto.field has field number 2:
+           repeated FieldDescriptorProto field = 2;
+         and FieldDescriptorProto.name has field number 1:
+           optional string name = 1;
+
+         Thus, the above path gives the location of a field name.  If we removed
+         the last element:
+           \[ 4, 3, 2, 7 \]
+         this path refers to the whole field declaration (from the beginning
+         of the label to the terminating semicolon). *)
+        span: int list;(** Always has exactly three or four elements: start line, start column,
+         end line (optional, otherwise assumed same as start line), end column.
+         These are packed into a single field for efficiency.  Note that line
+         and column numbers are zero-based -- typically you will want to add
+         1 to each before displaying to a user. *)
+        leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
+         comments appearing before and after the declaration which appear to be
+         attached to the declaration.
+
+         A series of line comments appearing on consecutive lines, with no other
+         tokens appearing on those lines, will be treated as a single comment.
+
+         leading_detached_comments will keep paragraphs of comments that appear
+         before (but not connected to) the current element. Each paragraph,
+         separated by empty lines, will be one comment element in the repeated
+         field.
+
+         Only the comment content is provided; comment markers (e.g. //) are
+         stripped out.  For block comments, leading whitespace and an asterisk
+         will be stripped from the beginning of each line other than the first.
+         Newlines are included in the output.
+
+         Examples:
+
+           optional int32 foo = 1;  // Comment attached to foo.
+           // Comment attached to bar.
+           optional int32 bar = 2;
+
+           optional string baz = 3;
+           // Comment attached to baz.
+           // Another line attached to baz.
+
+           // Comment attached to moo.
+           //
+           // Another line attached to moo.
+           optional double moo = 4;
+
+           // Detached comment for corge. This is not leading or trailing comments
+           // to moo or corge because there are blank lines separating it from
+           // both.
+
+           // Detached comment for corge paragraph 2.
+
+           optional string corge = 5;
+           /* Block comment attached
+            * to corge.  Leading asterisks
+            * will be removed. */
+           /* Block comment attached to
+            * grault. */
+           optional int32 grault = 6;
+
+           // ignored detached comments. *)
+        trailing_comments: string option;
+        leading_detached_comments: string list;
+        }
         type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = Location
         let name () = ".google.protobuf.SourceCodeInfo.Location"
-        type t = { path: int list; span: int list; leading_comments: string option; trailing_comments: string option; leading_detached_comments: string list }
+        type t = {
+        path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
+         location.
+
+         Each element is a field number or an index.  They form a path from
+         the root FileDescriptorProto to the place where the definition occurs.
+         For example, this path:
+           \[ 4, 3, 2, 7, 1 \]
+         refers to:
+           file.message_type(3)  // 4, 3
+               .field(7)         // 2, 7
+               .name()           // 1
+         This is because FileDescriptorProto.message_type has field number 4:
+           repeated DescriptorProto message_type = 4;
+         and DescriptorProto.field has field number 2:
+           repeated FieldDescriptorProto field = 2;
+         and FieldDescriptorProto.name has field number 1:
+           optional string name = 1;
+
+         Thus, the above path gives the location of a field name.  If we removed
+         the last element:
+           \[ 4, 3, 2, 7 \]
+         this path refers to the whole field declaration (from the beginning
+         of the label to the terminating semicolon). *)
+        span: int list;(** Always has exactly three or four elements: start line, start column,
+         end line (optional, otherwise assumed same as start line), end column.
+         These are packed into a single field for efficiency.  Note that line
+         and column numbers are zero-based -- typically you will want to add
+         1 to each before displaying to a user. *)
+        leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
+         comments appearing before and after the declaration which appear to be
+         attached to the declaration.
+
+         A series of line comments appearing on consecutive lines, with no other
+         tokens appearing on those lines, will be treated as a single comment.
+
+         leading_detached_comments will keep paragraphs of comments that appear
+         before (but not connected to) the current element. Each paragraph,
+         separated by empty lines, will be one comment element in the repeated
+         field.
+
+         Only the comment content is provided; comment markers (e.g. //) are
+         stripped out.  For block comments, leading whitespace and an asterisk
+         will be stripped from the beginning of each line other than the first.
+         Newlines are included in the output.
+
+         Examples:
+
+           optional int32 foo = 1;  // Comment attached to foo.
+           // Comment attached to bar.
+           optional int32 bar = 2;
+
+           optional string baz = 3;
+           // Comment attached to baz.
+           // Another line attached to baz.
+
+           // Comment attached to moo.
+           //
+           // Another line attached to moo.
+           optional double moo = 4;
+
+           // Detached comment for corge. This is not leading or trailing comments
+           // to moo or corge because there are blank lines separating it from
+           // both.
+
+           // Detached comment for corge paragraph 2.
+
+           optional string corge = 5;
+           /* Block comment attached
+            * to corge.  Leading asterisks
+            * will be removed. */
+           /* Block comment attached to
+            * grault. */
+           optional int32 grault = 6;
+
+           // ignored detached comments. *)
+        trailing_comments: string option;
+        leading_detached_comments: string list;
+        }
         type make_t = ?path:int list -> ?span:int list -> ?leading_comments:string -> ?trailing_comments:string -> ?leading_detached_comments:string list -> unit -> t
         let make ?(path = []) ?(span = []) ?leading_comments ?trailing_comments ?(leading_detached_comments = []) () = { path; span; leading_comments; trailing_comments; leading_detached_comments }
         let merge =
-          let merge_path = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "path", "path"), int32_int, packed) ) in
-          let merge_span = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "span", "span"), int32_int, packed) ) in
-          let merge_leading_comments = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "leading_comments", "leadingComments"), string) ) in
-          let merge_trailing_comments = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "trailing_comments", "trailingComments"), string) ) in
-          let merge_leading_detached_comments = Runtime'.Merge.merge Runtime'.Spec.( repeated ((6, "leading_detached_comments", "leadingDetachedComments"), string, not_packed) ) in
-          fun t1 t2 -> {
-            path = (merge_path t1.path t2.path);
-            span = (merge_span t1.span t2.span);
-            leading_comments = (merge_leading_comments t1.leading_comments t2.leading_comments);
-            trailing_comments = (merge_trailing_comments t1.trailing_comments t2.trailing_comments);
-            leading_detached_comments = (merge_leading_detached_comments t1.leading_detached_comments t2.leading_detached_comments);
-           }
+        let merge_path = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "path", "path"), int32_int, packed) ) in
+        let merge_span = Runtime'.Merge.merge Runtime'.Spec.( repeated ((2, "span", "span"), int32_int, packed) ) in
+        let merge_leading_comments = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "leading_comments", "leadingComments"), string) ) in
+        let merge_trailing_comments = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "trailing_comments", "trailingComments"), string) ) in
+        let merge_leading_detached_comments = Runtime'.Merge.merge Runtime'.Spec.( repeated ((6, "leading_detached_comments", "leadingDetachedComments"), string, not_packed) ) in
+        fun t1 t2 -> {
+        path = (merge_path t1.path t2.path);
+        span = (merge_span t1.span t2.span);
+        leading_comments = (merge_leading_comments t1.leading_comments t2.leading_comments);
+        trailing_comments = (merge_trailing_comments t1.trailing_comments t2.trailing_comments);
+        leading_detached_comments = (merge_leading_detached_comments t1.leading_detached_comments t2.leading_detached_comments);
+         }
         let spec () = Runtime'.Spec.( repeated ((1, "path", "path"), int32_int, packed) ^:: repeated ((2, "span", "span"), int32_int, packed) ^:: basic_opt ((3, "leading_comments", "leadingComments"), string) ^:: basic_opt ((4, "trailing_comments", "trailingComments"), string) ^:: repeated ((6, "leading_detached_comments", "leadingDetachedComments"), string, not_packed) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2474,11 +6267,57 @@ end = struct
       end
       let name () = ".google.protobuf.SourceCodeInfo"
       type t = (Location.t list)
+      (**
+      @param location A Location identifies a piece of source code in a .proto file which
+       corresponds to a particular definition.  This information is intended
+       to be useful to IDEs, code indexers, documentation generators, and similar
+       tools.
+
+       For example, say we have a file like:
+         message Foo \{
+           optional string foo = 1;
+         \}
+       Let's look at just the field definition:
+         optional string foo = 1;
+         ^       ^^     ^^  ^  ^^^
+         a       bc     de  f  ghi
+       We have the following locations:
+         span   path               represents
+         \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
+         \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
+         \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
+         \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
+         \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
+
+       Notes:
+       - A location may refer to a repeated field itself (i.e. not to any
+         particular index within it).  This is used whenever a set of elements are
+         logically enclosed in a single code segment.  For example, an entire
+         extend block (possibly containing multiple extension definitions) will
+         have an outer location whose path refers to the "extensions" repeated
+         field without an index.
+       - Multiple locations may have the same path.  This happens when a single
+         logical declaration is spread out across multiple places.  The most
+         obvious example is the "extend" block again -- there may be multiple
+         extend blocks in the same scope, each of which will have the same path.
+       - A location's span is not always a subset of its parent's span.  For
+         example, the "extendee" of an extension declaration appears at the
+         beginning of the "extend" block and is shared by all extensions within
+         the block.
+       - Just because a location's span is a subset of some other location's span
+         does not mean that it is a descendant.  For example, a "group" defines
+         both a type and a field in a single declaration.  Thus, the locations
+         corresponding to the type and field and their components will overlap.
+       - Code which tries to interpret locations should probably be designed to
+         ignore those that it doesn't understand, as more types of locations could
+         be recorded in the future.
+      *)
+
       type make_t = ?location:Location.t list -> unit -> t
       let make ?(location = []) () = (location)
       let merge =
-        let merge_location = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "location", "location"), (message (module Location)), not_packed) ) in
-        fun (t1_location) (t2_location) -> merge_location t1_location t2_location
+      let merge_location = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "location", "location"), (message (module Location)), not_packed) ) in
+      fun (t1_location) (t2_location) -> merge_location t1_location t2_location
       let spec () = Runtime'.Spec.( repeated ((1, "location", "location"), (message (module Location)), not_packed) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2499,61 +6338,137 @@ end = struct
     end
     and GeneratedCodeInfo : sig
       module rec Annotation : sig
-        val name: unit -> string
-        type t = { path: int list; source_file: string option; begin': int option; end': int option }
+        type t = {
+        path: int list;(** Identifies the element in the original source .proto file. This field
+         is formatted the same as SourceCodeInfo.Location.path. *)
+        source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
+        begin': int option;(** Identifies the starting offset in bytes in the generated code
+         that relates to the identified object. *)
+        end': int option;(** Identifies the ending offset in bytes in the generated code that
+         relates to the identified offset. The end offset should be one past
+         the last relevant byte (so the length of the text = end - begin). *)
+        }
         type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
-      val name: unit -> string
       type t = (Annotation.t list)
+      (**
+      @param annotation An Annotation connects some span of text in generated code to an element
+       of its generating .proto file.
+      *)
+
       type make_t = ?annotation:Annotation.t list -> unit -> t
       val make: make_t
+      (** Helper function to generate a message using default values *)
+
+      val to_proto: t -> Runtime'.Writer.t
+      (** Serialize the message to binary format *)
+
+      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from binary format *)
+
+      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+      (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+      val name: unit -> string
+      (** Fully qualified protobuf name of this message *)
+
+      (**/**)
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
-      val to_proto: t -> Runtime'.Writer.t
-      val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
       val from_proto_exn: Runtime'.Reader.t -> t
-      val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
       val from_json_exn: Runtime'.Json.t -> t
-      val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+      (**/**)
     end = struct
+      module This'_ = GeneratedCodeInfo
       module rec Annotation : sig
-        val name: unit -> string
-        type t = { path: int list; source_file: string option; begin': int option; end': int option }
+        type t = {
+        path: int list;(** Identifies the element in the original source .proto file. This field
+         is formatted the same as SourceCodeInfo.Location.path. *)
+        source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
+        begin': int option;(** Identifies the starting offset in bytes in the generated code
+         that relates to the identified object. *)
+        end': int option;(** Identifies the ending offset in bytes in the generated code that
+         relates to the identified offset. The end offset should be one past
+         the last relevant byte (so the length of the text = end - begin). *)
+        }
         type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = Annotation
         let name () = ".google.protobuf.GeneratedCodeInfo.Annotation"
-        type t = { path: int list; source_file: string option; begin': int option; end': int option }
+        type t = {
+        path: int list;(** Identifies the element in the original source .proto file. This field
+         is formatted the same as SourceCodeInfo.Location.path. *)
+        source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
+        begin': int option;(** Identifies the starting offset in bytes in the generated code
+         that relates to the identified object. *)
+        end': int option;(** Identifies the ending offset in bytes in the generated code that
+         relates to the identified offset. The end offset should be one past
+         the last relevant byte (so the length of the text = end - begin). *)
+        }
         type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         let make ?(path = []) ?source_file ?begin' ?end' () = { path; source_file; begin'; end' }
         let merge =
-          let merge_path = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "path", "path"), int32_int, packed) ) in
-          let merge_source_file = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "source_file", "sourceFile"), string) ) in
-          let merge_begin' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "begin", "begin"), int32_int) ) in
-          let merge_end' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "end", "end"), int32_int) ) in
-          fun t1 t2 -> {
-            path = (merge_path t1.path t2.path);
-            source_file = (merge_source_file t1.source_file t2.source_file);
-            begin' = (merge_begin' t1.begin' t2.begin');
-            end' = (merge_end' t1.end' t2.end');
-           }
+        let merge_path = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "path", "path"), int32_int, packed) ) in
+        let merge_source_file = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "source_file", "sourceFile"), string) ) in
+        let merge_begin' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "begin", "begin"), int32_int) ) in
+        let merge_end' = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "end", "end"), int32_int) ) in
+        fun t1 t2 -> {
+        path = (merge_path t1.path t2.path);
+        source_file = (merge_source_file t1.source_file t2.source_file);
+        begin' = (merge_begin' t1.begin' t2.begin');
+        end' = (merge_end' t1.end' t2.end');
+         }
         let spec () = Runtime'.Spec.( repeated ((1, "path", "path"), int32_int, packed) ^:: basic_opt ((2, "source_file", "sourceFile"), string) ^:: basic_opt ((3, "begin", "begin"), int32_int) ^:: basic_opt ((4, "end", "end"), int32_int) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -2574,11 +6489,16 @@ end = struct
       end
       let name () = ".google.protobuf.GeneratedCodeInfo"
       type t = (Annotation.t list)
+      (**
+      @param annotation An Annotation connects some span of text in generated code to an element
+       of its generating .proto file.
+      *)
+
       type make_t = ?annotation:Annotation.t list -> unit -> t
       let make ?(annotation = []) () = (annotation)
       let merge =
-        let merge_annotation = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "annotation", "annotation"), (message (module Annotation)), not_packed) ) in
-        fun (t1_annotation) (t2_annotation) -> merge_annotation t1_annotation t2_annotation
+      let merge_annotation = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "annotation", "annotation"), (message (module Annotation)), not_packed) ) in
+      fun (t1_annotation) (t2_annotation) -> merge_annotation t1_annotation t2_annotation
       let spec () = Runtime'.Spec.( repeated ((1, "annotation", "annotation"), (message (module Annotation)), not_packed) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.Serialize.serialize (spec ()) in

--- a/src/spec/descriptor.ml
+++ b/src/spec/descriptor.ml
@@ -26,6 +26,11 @@ end
 (**/**)
 module rec Google : sig
   module rec Protobuf : sig
+
+    (**
+       The protocol compiler can output a FileDescriptorSet containing the .proto
+       files it parses.
+    *)
     module rec FileDescriptorSet : sig
       val name: unit -> string
       type t = (FileDescriptorProto.t list)

--- a/src/spec/descriptor.ml
+++ b/src/spec/descriptor.ml
@@ -28,8 +28,8 @@ module rec Google : sig
   module rec Protobuf : sig
 
     (**
-       The protocol compiler can output a FileDescriptorSet containing the .proto
-       files it parses.
+      The protocol compiler can output a FileDescriptorSet containing the .proto
+      files it parses.
     *)
     module rec FileDescriptorSet : sig
       type t = (FileDescriptorProto.t list)
@@ -72,14 +72,14 @@ module rec Google : sig
       extension: FieldDescriptorProto.t list;
       options: FileOptions.t option;
       source_code_info: SourceCodeInfo.t option;(** This field contains optional information about the original source code.
-       You may safely remove this entire field without harming runtime
-       functionality of the descriptors -- the information is needed only by
-       development tools. *)
+      You may safely remove this entire field without harming runtime
+      functionality of the descriptors -- the information is needed only by
+      development tools. *)
       public_dependency: int list;(** Indexes of the public imported files in the dependency list above. *)
       weak_dependency: int list;(** Indexes of the weak imported files in the dependency list.
-       For Google-internal migration only. Do not use. *)
+      For Google-internal migration only. Do not use. *)
       syntax: string option;(** The syntax of the proto file.
-       The supported values are "proto2" and "proto3". *)
+      The supported values are "proto2" and "proto3". *)
       }
       val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -144,9 +144,9 @@ module rec Google : sig
       end
 
       (**
-         Range of reserved tag numbers. Reserved tag numbers may not be used by
-         fields or extension ranges in the same message. Reserved ranges may
-         not overlap.
+        Range of reserved tag numbers. Reserved tag numbers may not be used by
+        fields or extension ranges in the same message. Reserved ranges may
+        not overlap.
       *)
       and ReservedRange : sig
         type t = {
@@ -190,7 +190,7 @@ module rec Google : sig
       oneof_decl: OneofDescriptorProto.t list;
       reserved_range: ReservedRange.t list;
       reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
-       A given name may only be reserved once. *)
+      A given name may only be reserved once. *)
       }
       val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -256,20 +256,20 @@ module rec Google : sig
         type t =
           | TYPE_DOUBLE
           (**
-             0 is reserved for errors.
-             Order is weird for historical reasons.
+            0 is reserved for errors.
+            Order is weird for historical reasons.
           *)
           | TYPE_FLOAT
           | TYPE_INT64
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+            negative values are likely.
           *)
           | TYPE_UINT64
           | TYPE_INT32
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+            negative values are likely.
           *)
           | TYPE_FIXED64
           | TYPE_FIXED32
@@ -277,10 +277,10 @@ module rec Google : sig
           | TYPE_STRING
           | TYPE_GROUP
           (**
-             Tag-delimited aggregate.
-             Group type is deprecated and not supported in proto3. However, Proto3
-             implementations should still be able to parse the group wire format and
-             treat group fields as unknown fields.
+            Tag-delimited aggregate.
+            Group type is deprecated and not supported in proto3. However, Proto3
+            implementations should still be able to parse the group wire format and
+            treat group fields as unknown fields.
           *)
           | TYPE_MESSAGE
           (** Length-delimited aggregate. *)
@@ -327,48 +327,48 @@ module rec Google : sig
       type t = {
       name: string option;
       extendee: string option;(** For extensions, this is the name of the type being extended.  It is
-       resolved in the same manner as type_name. *)
+      resolved in the same manner as type_name. *)
       number: int option;
       label: Label.t option;
       type': Type.t option;(** If type_name is set, this need not be set.  If both this and type_name
-       are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
+      are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
       type_name: string option;(** For message and enum types, this is the name of the type.  If the name
-       starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-       rules are used to find the type (i.e. first the nested types within this
-       message are searched, then within the parent, on up to the root
-       namespace). *)
+      starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+      rules are used to find the type (i.e. first the nested types within this
+      message are searched, then within the parent, on up to the root
+      namespace). *)
       default_value: string option;(** For numeric types, contains the original text representation of the value.
-       For booleans, "true" or "false".
-       For strings, contains the default text contents (not escaped in any way).
-       For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
+      For booleans, "true" or "false".
+      For strings, contains the default text contents (not escaped in any way).
+      For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
       options: FieldOptions.t option;
       oneof_index: int option;(** If set, gives the index of a oneof in the containing type's oneof_decl
-       list.  This field is a member of that oneof. *)
+      list.  This field is a member of that oneof. *)
       json_name: string option;(** JSON name of this field. The value is set by protocol compiler. If the
-       user has set a "json_name" option on this field, that option's value
-       will be used. Otherwise, it's deduced from the field's name by converting
-       it to camelCase. *)
+      user has set a "json_name" option on this field, that option's value
+      will be used. Otherwise, it's deduced from the field's name by converting
+      it to camelCase. *)
       proto3_optional: bool option;(** If true, this is a proto3 "optional". When a proto3 field is optional, it
-       tracks presence regardless of field type.
+      tracks presence regardless of field type.
 
-       When proto3_optional is true, this field must be belong to a oneof to
-       signal to old proto3 clients that presence is tracked for this field. This
-       oneof is known as a "synthetic" oneof, and this field must be its sole
-       member (each proto3 optional field gets its own synthetic oneof). Synthetic
-       oneofs exist in the descriptor only, and do not generate any API. Synthetic
-       oneofs must be ordered after all "real" oneofs.
+      When proto3_optional is true, this field must be belong to a oneof to
+      signal to old proto3 clients that presence is tracked for this field. This
+      oneof is known as a "synthetic" oneof, and this field must be its sole
+      member (each proto3 optional field gets its own synthetic oneof). Synthetic
+      oneofs exist in the descriptor only, and do not generate any API. Synthetic
+      oneofs must be ordered after all "real" oneofs.
 
-       For message fields, proto3_optional doesn't create any semantic change,
-       since non-repeated message fields always track presence. However it still
-       indicates the semantic detail of whether the user wrote "optional" or not.
-       This can be useful for round-tripping the .proto file. For consistency we
-       give message fields a synthetic oneof also, even though it is not required
-       to track presence. This is especially important because the parser can't
-       tell if a field is a message or an enum, so it must always create a
-       synthetic oneof.
+      For message fields, proto3_optional doesn't create any semantic change,
+      since non-repeated message fields always track presence. However it still
+      indicates the semantic detail of whether the user wrote "optional" or not.
+      This can be useful for round-tripping the .proto file. For consistency we
+      give message fields a synthetic oneof also, even though it is not required
+      to track presence. This is especially important because the parser can't
+      tell if a field is a message or an enum, so it must always create a
+      synthetic oneof.
 
-       Proto2 optional fields do not set this flag, because they already indicate
-       optional with `LABEL_OPTIONAL`. *)
+      Proto2 optional fields do not set this flag, because they already indicate
+      optional with `LABEL_OPTIONAL`. *)
       }
       val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -434,12 +434,12 @@ module rec Google : sig
     and EnumDescriptorProto : sig
 
       (**
-         Range of reserved numeric values. Reserved values may not be used by
-         entries in the same enum. Reserved ranges may not overlap.
+        Range of reserved numeric values. Reserved values may not be used by
+        entries in the same enum. Reserved ranges may not overlap.
 
-         Note that this is distinct from DescriptorProto.ReservedRange in that it
-         is inclusive such that it can appropriately represent the entire int32
-         domain.
+        Note that this is distinct from DescriptorProto.ReservedRange in that it
+        is inclusive such that it can appropriately represent the entire int32
+        domain.
       *)
       module rec EnumReservedRange : sig
         type t = {
@@ -477,10 +477,10 @@ module rec Google : sig
       value: EnumValueDescriptorProto.t list;
       options: EnumOptions.t option;
       reserved_range: EnumReservedRange.t list;(** Range of reserved numeric values. Reserved numeric values may not be used
-       by enum values in the same enum declaration. Reserved ranges may not
-       overlap. *)
+      by enum values in the same enum declaration. Reserved ranges may not
+      overlap. *)
       reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
-       be reserved once. *)
+      be reserved once. *)
       }
       val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -582,7 +582,7 @@ module rec Google : sig
       type t = {
       name: string option;
       input_type: string option;(** Input and output type names.  These are resolved in the same way as
-       FieldDescriptorProto.type_name, but must refer to a message type. *)
+      FieldDescriptorProto.type_name, but must refer to a message type. *)
       output_type: string option;
       options: MethodOptions.t option;
       client_streaming: bool;(** Identifies if client streams multiple client messages *)
@@ -623,9 +623,10 @@ module rec Google : sig
           (** Generate complete code for parsing, serialization, *)
           | CODE_SIZE
           (**
-             etc.
+            etc.
 
-             Use ReflectionOps to implement these methods.
+
+            Use ReflectionOps to implement these methods.
           *)
           | LITE_RUNTIME
           (** Generate code using MessageLite and the lite runtime. *)
@@ -643,74 +644,73 @@ module rec Google : sig
       end
       type t = {
       java_package: string option;(** Sets the Java package where classes generated from this .proto will be
-       placed.  By default, the proto package is used, but this is often
-       inappropriate because proto packages do not normally start with backwards
-       domain names. *)
+      placed.  By default, the proto package is used, but this is often
+      inappropriate because proto packages do not normally start with backwards
+      domain names. *)
       java_outer_classname: string option;(** Controls the name of the wrapper Java class generated for the .proto file.
-       That class will always contain the .proto file's getDescriptor() method as
-       well as any top-level extensions defined in the .proto file.
-       If java_multiple_files is disabled, then all the other classes from the
-       .proto file will be nested inside the single wrapper outer class. *)
+      That class will always contain the .proto file's getDescriptor() method as
+      well as any top-level extensions defined in the .proto file.
+      If java_multiple_files is disabled, then all the other classes from the
+      .proto file will be nested inside the single wrapper outer class. *)
       optimize_for: OptimizeMode.t;(** Clients can define custom options in extensions of this message.
-       See the documentation for the "Options" section above. *)
+      See the documentation for the "Options" section above. *)
       java_multiple_files: bool;(** If enabled, then the Java code generator will generate a separate .java
-       file for each top-level message, enum, and service defined in the .proto
-       file.  Thus, these types will *not* be nested inside the wrapper class
-       named by java_outer_classname.  However, the wrapper class will still be
-       generated to contain the file's getDescriptor() method as well as any
-       top-level extensions defined in the file. *)
+      file for each top-level message, enum, and service defined in the .proto
+      file.  Thus, these types will *not* be nested inside the wrapper class
+      named by java_outer_classname.  However, the wrapper class will still be
+      generated to contain the file's getDescriptor() method as well as any
+      top-level extensions defined in the file. *)
       go_package: string option;(** Sets the Go package where structs generated from this .proto will be
-       placed. If omitted, the Go package will be derived from the following:
-         - The basename of the package import path, if provided.
-         - Otherwise, the package statement in the .proto file, if present.
-         - Otherwise, the basename of the .proto file, without extension. *)
+      placed. If omitted, the Go package will be derived from the following:
+      - The basename of the package import path, if provided.
+      - Otherwise, the package statement in the .proto file, if present.
+      - Otherwise, the basename of the .proto file, without extension. *)
       cc_generic_services: bool;(** Should generic services be generated in each language?  "Generic" services
-       are not specific to any particular RPC system.  They are generated by the
-       main code generators in each language (without additional plugins).
-       Generic services were the only kind of service generation supported by
-       early versions of google.protobuf.
+      are not specific to any particular RPC system.  They are generated by the
+      main code generators in each language (without additional plugins).
+      Generic services were the only kind of service generation supported by
+      early versions of google.protobuf.
 
-       Generic services are now considered deprecated in favor of using plugins
-       that generate code specific to your particular RPC system.  Therefore,
-       these default to false.  Old code which depends on generic services should
-       explicitly set them to true. *)
+      Generic services are now considered deprecated in favor of using plugins
+      that generate code specific to your particular RPC system.  Therefore,
+      these default to false.  Old code which depends on generic services should
+      explicitly set them to true. *)
       java_generic_services: bool;
       py_generic_services: bool;
-      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"];(** This option does nothing.
-      @deprecated deprecated in proto file *)
+      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Marked as deprecated in the .proto file"];(** This option does nothing. *)
       deprecated: bool;(** Is this file deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for everything in the file, or it will be completely ignored; in the very
-       least, this is a formalization for deprecating files. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for everything in the file, or it will be completely ignored; in the very
+      least, this is a formalization for deprecating files. *)
       java_string_check_utf8: bool;(** If set true, then the Java2 code generator will generate code that
-       throws an exception whenever an attempt is made to assign a non-UTF-8
-       byte sequence to a string field.
-       Message reflection will do the same.
-       However, an extension field still accepts non-UTF-8 byte sequences.
-       This option has no effect on when used with the lite runtime. *)
+      throws an exception whenever an attempt is made to assign a non-UTF-8
+      byte sequence to a string field.
+      Message reflection will do the same.
+      However, an extension field still accepts non-UTF-8 byte sequences.
+      This option has no effect on when used with the lite runtime. *)
       cc_enable_arenas: bool;(** Enables the use of arenas for the proto messages in this file. This applies
-       only to generated classes for C++. *)
+      only to generated classes for C++. *)
       objc_class_prefix: string option;(** Sets the objective c class prefix which is prepended to all objective c
-       generated classes from this .proto. There is no default. *)
+      generated classes from this .proto. There is no default. *)
       csharp_namespace: string option;(** Namespace for generated classes; defaults to the package. *)
       swift_prefix: string option;(** By default Swift generators will take the proto package and CamelCase it
-       replacing '.' with underscore and use that to prefix the types/symbols
-       defined. When this options is provided, they will use this value instead
-       to prefix the types/symbols defined. *)
+      replacing '.' with underscore and use that to prefix the types/symbols
+      defined. When this options is provided, they will use this value instead
+      to prefix the types/symbols defined. *)
       php_class_prefix: string option;(** Sets the php class prefix which is prepended to all php generated classes
-       from this .proto. Default is empty. *)
+      from this .proto. Default is empty. *)
       php_namespace: string option;(** Use this option to change the namespace of php generated classes. Default
-       is empty. When this option is empty, the package name will be used for
-       determining the namespace. *)
+      is empty. When this option is empty, the package name will be used for
+      determining the namespace. *)
       php_generic_services: bool;
       php_metadata_namespace: string option;(** Use this option to change the namespace of php generated metadata classes.
-       Default is empty. When this option is empty, the proto file name will be
-       used for determining the namespace. *)
+      Default is empty. When this option is empty, the proto file name will be
+      used for determining the namespace. *)
       ruby_package: string option;(** Use this option to change the package of ruby generated classes. Default
-       is empty. When this option is not set, the package name will be used for
-       determining the ruby package. *)
+      is empty. When this option is not set, the package name will be used for
+      determining the ruby package. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here.
-       See the documentation for the "Options" section above. *)
+      See the documentation for the "Options" section above. *)
       extensions': Runtime'.Extensions.t;
       }
       val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
@@ -742,51 +742,56 @@ module rec Google : sig
     and MessageOptions : sig
       type t = {
       message_set_wire_format: bool;(** Set true to use the old proto1 MessageSet wire format for extensions.
-       This is provided for backwards-compatibility with the MessageSet wire
-       format.  You should not use this for any other reason:  It's less
-       efficient, has fewer features, and is more complicated.
+      This is provided for backwards-compatibility with the MessageSet wire
+      format.  You should not use this for any other reason:  It's less
+      efficient, has fewer features, and is more complicated.
 
-       The message must be defined exactly as follows:
-         message Foo \{
+      The message must be defined exactly as follows:
+      {v
+         message Foo {
            option message_set_wire_format = true;
            extensions 4 to max;
-         \}
-       Note that the message cannot have any defined fields; MessageSets only
-       have extensions.
+         }
+      v}
+      Note that the message cannot have any defined fields; MessageSets only
+      have extensions.
 
-       All extensions of your type must be singular messages; e.g. they cannot
-       be int32s, enums, or repeated messages.
+      All extensions of your type must be singular messages; e.g. they cannot
+      be int32s, enums, or repeated messages.
 
-       Because this is an option, the above two restrictions are not enforced by
-       the protocol compiler. *)
+      Because this is an option, the above two restrictions are not enforced by
+      the protocol compiler. *)
       no_standard_descriptor_accessor: bool;(** Disables the generation of the standard "descriptor()" accessor, which can
-       conflict with a field of the same name.  This is meant to make migration
-       from proto1 easier; new code should avoid fields named "descriptor". *)
+      conflict with a field of the same name.  This is meant to make migration
+      from proto1 easier; new code should avoid fields named "descriptor". *)
       deprecated: bool;(** Is this message deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the message, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating messages. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the message, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating messages. *)
       map_entry: bool option;(** Whether the message is an automatically generated map entry type for the
-       maps field.
+      maps field.
 
-       For maps fields:
+      For maps fields:
+      {v
            map<KeyType, ValueType> map_field = 1;
-       The parsed descriptor looks like:
-           message MapFieldEntry \{
+      v}
+      The parsed descriptor looks like:
+      {v
+           message MapFieldEntry {
                option map_entry = true;
                optional KeyType key = 1;
                optional ValueType value = 2;
-           \}
+           }
            repeated MapFieldEntry map_field = 1;
+      v}
+      Implementations may choose not to generate the map_entry=true message, but
+      use a native map in the target language to hold the keys and values.
+      The reflection APIs in such implementations still need to work as
+      if the field is a repeated message field.
 
-       Implementations may choose not to generate the map_entry=true message, but
-       use a native map in the target language to hold the keys and values.
-       The reflection APIs in such implementations still need to work as
-       if the field is a repeated message field.
-
-       NOTE: Do not set the option in .proto files. Always use the maps syntax
-       instead. The option should only be implicitly set by the proto compiler
-       parser. *)
+      NOTE: Do not set the option in .proto files. Always use the maps syntax
+      instead. The option should only be implicitly set by the proto compiler
+      parser. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -857,64 +862,64 @@ module rec Google : sig
       end
       type t = {
       ctype: CType.t;(** The ctype option instructs the C++ code generator to use a different
-       representation of the field than it normally would.  See the specific
-       options below.  This option is not yet implemented in the open source
-       release -- sorry, we'll try to include it in a future version! *)
+      representation of the field than it normally would.  See the specific
+      options below.  This option is not yet implemented in the open source
+      release -- sorry, we'll try to include it in a future version! *)
       packed: bool option;(** The packed option can be enabled for repeated primitive fields to enable
-       a more efficient representation on the wire. Rather than repeatedly
-       writing the tag and type for each element, the entire array is encoded as
-       a single length-delimited blob. In proto3, only explicit setting it to
-       false will avoid using packed encoding. *)
+      a more efficient representation on the wire. Rather than repeatedly
+      writing the tag and type for each element, the entire array is encoded as
+      a single length-delimited blob. In proto3, only explicit setting it to
+      false will avoid using packed encoding. *)
       deprecated: bool;(** Clients can define custom options in extensions of this message. See above. *)
       lazy': bool;(** Should this field be parsed lazily?  Lazy applies only to message-type
-       fields.  It means that when the outer message is initially parsed, the
-       inner message's contents will not be parsed but instead stored in encoded
-       form.  The inner message will actually be parsed when it is first accessed.
+      fields.  It means that when the outer message is initially parsed, the
+      inner message's contents will not be parsed but instead stored in encoded
+      form.  The inner message will actually be parsed when it is first accessed.
 
-       This is only a hint.  Implementations are free to choose whether to use
-       eager or lazy parsing regardless of the value of this option.  However,
-       setting this option true suggests that the protocol author believes that
-       using lazy parsing on this field is worth the additional bookkeeping
-       overhead typically needed to implement it.
+      This is only a hint.  Implementations are free to choose whether to use
+      eager or lazy parsing regardless of the value of this option.  However,
+      setting this option true suggests that the protocol author believes that
+      using lazy parsing on this field is worth the additional bookkeeping
+      overhead typically needed to implement it.
 
-       This option does not affect the public interface of any generated code;
-       all method signatures remain the same.  Furthermore, thread-safety of the
-       interface is not affected by this option; const methods remain safe to
-       call from multiple threads concurrently, while non-const methods continue
-       to require exclusive access.
+      This option does not affect the public interface of any generated code;
+      all method signatures remain the same.  Furthermore, thread-safety of the
+      interface is not affected by this option; const methods remain safe to
+      call from multiple threads concurrently, while non-const methods continue
+      to require exclusive access.
 
 
-       Note that implementations may choose not to check required fields within
-       a lazy sub-message.  That is, calling IsInitialized() on the outer message
-       may return true even if the inner message has missing required fields.
-       This is necessary because otherwise the inner message would have to be
-       parsed in order to perform the check, defeating the purpose of lazy
-       parsing.  An implementation which chooses not to check required fields
-       must be consistent about it.  That is, for any particular sub-message, the
-       implementation must either *always* check its required fields, or *never*
-       check its required fields, regardless of whether or not the message has
-       been parsed.
+      Note that implementations may choose not to check required fields within
+      a lazy sub-message.  That is, calling IsInitialized() on the outer message
+      may return true even if the inner message has missing required fields.
+      This is necessary because otherwise the inner message would have to be
+      parsed in order to perform the check, defeating the purpose of lazy
+      parsing.  An implementation which chooses not to check required fields
+      must be consistent about it.  That is, for any particular sub-message, the
+      implementation must either *always* check its required fields, or *never*
+      check its required fields, regardless of whether or not the message has
+      been parsed.
 
-       As of 2021, lazy does no correctness checks on the byte stream during
-       parsing.  This may lead to crashes if and when an invalid byte stream is
-       finally parsed upon access.
+      As of 2021, lazy does no correctness checks on the byte stream during
+      parsing.  This may lead to crashes if and when an invalid byte stream is
+      finally parsed upon access.
 
-       TODO(b/211906113):  Enable validation on lazy fields. *)
+      TODO(b/211906113):  Enable validation on lazy fields. *)
       jstype: JSType.t;(** The jstype option determines the JavaScript type used for values of the
-       field.  The option is permitted only for 64 bit integral and fixed types
-       (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
-       is represented as JavaScript string, which avoids loss of precision that
-       can happen when a large value is converted to a floating point JavaScript.
-       Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
-       use the JavaScript "number" type.  The behavior of the default option
-       JS_NORMAL is implementation dependent.
+      field.  The option is permitted only for 64 bit integral and fixed types
+      (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+      is represented as JavaScript string, which avoids loss of precision that
+      can happen when a large value is converted to a floating point JavaScript.
+      Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+      use the JavaScript "number" type.  The behavior of the default option
+      JS_NORMAL is implementation dependent.
 
-       This option is an enum to permit additional types to be added, e.g.
-       goog.math.Integer. *)
+      This option is an enum to permit additional types to be added, e.g.
+      goog.math.Integer. *)
       weak: bool;(** For Google-internal migration only. Do not use. *)
       unverified_lazy: bool;(** unverified_lazy does no correctness checks on the byte stream. This should
-       only be used where lazy with verification is prohibitive for performance
-       reasons. *)
+      only be used where lazy with verification is prohibitive for performance
+      reasons. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -978,11 +983,11 @@ module rec Google : sig
     and EnumOptions : sig
       type t = {
       allow_alias: bool option;(** Set this option to true to allow mapping different tag names to the same
-       value. *)
+      value. *)
       deprecated: bool;(** Is this enum deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the enum, or it will be completely ignored; in the very least, this
-       is a formalization for deprecating enums. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the enum, or it will be completely ignored; in the very least, this
+      is a formalization for deprecating enums. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -1015,9 +1020,9 @@ module rec Google : sig
     and EnumValueOptions : sig
       type t = {
       deprecated: bool;(** Is this enum value deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the enum value, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating enum values. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the enum value, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating enum values. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -1050,9 +1055,9 @@ module rec Google : sig
     and ServiceOptions : sig
       type t = {
       deprecated: bool;(** Is this service deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the service, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating services. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the service, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating services. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -1085,9 +1090,9 @@ module rec Google : sig
     and MethodOptions : sig
 
       (**
-         Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-         or neither? HTTP based RPC implementation may choose GET verb for safe
-         methods, and PUT verb for idempotent methods instead of the default POST.
+        Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+        or neither? HTTP based RPC implementation may choose GET verb for safe
+        methods, and PUT verb for idempotent methods instead of the default POST.
       *)
       module rec IdempotencyLevel : sig
         type t =
@@ -1110,9 +1115,9 @@ module rec Google : sig
       end
       type t = {
       deprecated: bool;(** Is this method deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the method, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating methods. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the method, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating methods. *)
       idempotency_level: IdempotencyLevel.t;
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
@@ -1145,21 +1150,21 @@ module rec Google : sig
     end
 
     (**
-       A message representing a option the parser does not recognize. This only
-       appears in options protos created by the compiler::Parser class.
-       DescriptorPool resolves these when building Descriptor objects. Therefore,
-       options protos in descriptor objects (e.g. returned by Descriptor::options(),
-       or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-       in them.
+      A message representing a option the parser does not recognize. This only
+      appears in options protos created by the compiler::Parser class.
+      DescriptorPool resolves these when building Descriptor objects. Therefore,
+      options protos in descriptor objects (e.g. returned by Descriptor::options(),
+      or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+      in them.
     *)
     and UninterpretedOption : sig
 
       (**
-         The name of the uninterpreted option.  Each string represents a segment in
-         a dot-separated name.  is_extension is true iff a segment represents an
-         extension (denoted with parentheses in options specs in .proto files).
-         E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
-         "foo.(bar.baz).moo".
+        The name of the uninterpreted option.  Each string represents a segment in
+        a dot-separated name.  is_extension is true iff a segment represents an
+        extension (denoted with parentheses in options specs in .proto files).
+        E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
+        "foo.(bar.baz).moo".
       *)
       module rec NamePart : sig
         type t = {
@@ -1195,7 +1200,7 @@ module rec Google : sig
       type t = {
       name: NamePart.t list;
       identifier_value: string option;(** The value of the uninterpreted option, in whatever type the tokenizer
-       identified it as during parsing. Exactly one of these should be set. *)
+      identified it as during parsing. Exactly one of these should be set. *)
       positive_int_value: int option;
       negative_int_value: int option;
       double_value: float option;
@@ -1230,59 +1235,70 @@ module rec Google : sig
     end
 
     (**
-       Encapsulates information about the original source file from which a
-       FileDescriptorProto was generated.
+      Encapsulates information about the original source file from which a
+      FileDescriptorProto was generated.
     *)
     and SourceCodeInfo : sig
       module rec Location : sig
         type t = {
         path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
-         location.
+        location.
 
-         Each element is a field number or an index.  They form a path from
-         the root FileDescriptorProto to the place where the definition occurs.
-         For example, this path:
-           \[ 4, 3, 2, 7, 1 \]
-         refers to:
+        Each element is a field number or an index.  They form a path from
+        the root FileDescriptorProto to the place where the definition occurs.
+        For example, this path:
+        {v
+           [ 4, 3, 2, 7, 1 ]
+        v}
+        refers to:
+        {v
            file.message_type(3)  // 4, 3
                .field(7)         // 2, 7
                .name()           // 1
-         This is because FileDescriptorProto.message_type has field number 4:
+        v}
+        This is because FileDescriptorProto.message_type has field number 4:
+        {v
            repeated DescriptorProto message_type = 4;
-         and DescriptorProto.field has field number 2:
+        v}
+        and DescriptorProto.field has field number 2:
+        {v
            repeated FieldDescriptorProto field = 2;
-         and FieldDescriptorProto.name has field number 1:
+        v}
+        and FieldDescriptorProto.name has field number 1:
+        {v
            optional string name = 1;
-
-         Thus, the above path gives the location of a field name.  If we removed
-         the last element:
-           \[ 4, 3, 2, 7 \]
-         this path refers to the whole field declaration (from the beginning
-         of the label to the terminating semicolon). *)
+        v}
+        Thus, the above path gives the location of a field name.  If we removed
+        the last element:
+        {v
+           [ 4, 3, 2, 7 ]
+        v}
+        this path refers to the whole field declaration (from the beginning
+        of the label to the terminating semicolon). *)
         span: int list;(** Always has exactly three or four elements: start line, start column,
-         end line (optional, otherwise assumed same as start line), end column.
-         These are packed into a single field for efficiency.  Note that line
-         and column numbers are zero-based -- typically you will want to add
-         1 to each before displaying to a user. *)
+        end line (optional, otherwise assumed same as start line), end column.
+        These are packed into a single field for efficiency.  Note that line
+        and column numbers are zero-based -- typically you will want to add
+        1 to each before displaying to a user. *)
         leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
-         comments appearing before and after the declaration which appear to be
-         attached to the declaration.
+        comments appearing before and after the declaration which appear to be
+        attached to the declaration.
 
-         A series of line comments appearing on consecutive lines, with no other
-         tokens appearing on those lines, will be treated as a single comment.
+        A series of line comments appearing on consecutive lines, with no other
+        tokens appearing on those lines, will be treated as a single comment.
 
-         leading_detached_comments will keep paragraphs of comments that appear
-         before (but not connected to) the current element. Each paragraph,
-         separated by empty lines, will be one comment element in the repeated
-         field.
+        leading_detached_comments will keep paragraphs of comments that appear
+        before (but not connected to) the current element. Each paragraph,
+        separated by empty lines, will be one comment element in the repeated
+        field.
 
-         Only the comment content is provided; comment markers (e.g. //) are
-         stripped out.  For block comments, leading whitespace and an asterisk
-         will be stripped from the beginning of each line other than the first.
-         Newlines are included in the output.
+        Only the comment content is provided; comment markers (e.g. //) are
+        stripped out.  For block comments, leading whitespace and an asterisk
+        will be stripped from the beginning of each line other than the first.
+        Newlines are included in the output.
 
-         Examples:
-
+        Examples:
+        {v
            optional int32 foo = 1;  // Comment attached to foo.
            // Comment attached to bar.
            optional int32 bar = 2;
@@ -1310,7 +1326,8 @@ module rec Google : sig
             * grault. */
            optional int32 grault = 6;
 
-           // ignored detached comments. *)
+           // ignored detached comments.
+        v} *)
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
@@ -1342,49 +1359,54 @@ module rec Google : sig
       end
       type t = (Location.t list)
       (**
-      @param location A Location identifies a piece of source code in a .proto file which
-       corresponds to a particular definition.  This information is intended
-       to be useful to IDEs, code indexers, documentation generators, and similar
-       tools.
+      A Location identifies a piece of source code in a .proto file which
+      corresponds to a particular definition.  This information is intended
+      to be useful to IDEs, code indexers, documentation generators, and similar
+      tools.
 
-       For example, say we have a file like:
-         message Foo \{
+      For example, say we have a file like:
+      {v
+         message Foo {
            optional string foo = 1;
-         \}
-       Let's look at just the field definition:
+         }
+      v}
+      Let's look at just the field definition:
+      {v
          optional string foo = 1;
          ^       ^^     ^^  ^  ^^^
          a       bc     de  f  ghi
-       We have the following locations:
+      v}
+      We have the following locations:
+      {v
          span   path               represents
-         \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
-         \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
-         \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
-         \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
-         \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
-
-       Notes:
-       - A location may refer to a repeated field itself (i.e. not to any
-         particular index within it).  This is used whenever a set of elements are
-         logically enclosed in a single code segment.  For example, an entire
-         extend block (possibly containing multiple extension definitions) will
-         have an outer location whose path refers to the "extensions" repeated
-         field without an index.
-       - Multiple locations may have the same path.  This happens when a single
-         logical declaration is spread out across multiple places.  The most
-         obvious example is the "extend" block again -- there may be multiple
-         extend blocks in the same scope, each of which will have the same path.
-       - A location's span is not always a subset of its parent's span.  For
-         example, the "extendee" of an extension declaration appears at the
-         beginning of the "extend" block and is shared by all extensions within
-         the block.
-       - Just because a location's span is a subset of some other location's span
-         does not mean that it is a descendant.  For example, a "group" defines
-         both a type and a field in a single declaration.  Thus, the locations
-         corresponding to the type and field and their components will overlap.
-       - Code which tries to interpret locations should probably be designed to
-         ignore those that it doesn't understand, as more types of locations could
-         be recorded in the future.
+         [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+         [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+         [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+         [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+         [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+      v}
+      Notes:
+      - A location may refer to a repeated field itself (i.e. not to any
+      particular index within it).  This is used whenever a set of elements are
+      logically enclosed in a single code segment.  For example, an entire
+      extend block (possibly containing multiple extension definitions) will
+      have an outer location whose path refers to the "extensions" repeated
+      field without an index.
+      - Multiple locations may have the same path.  This happens when a single
+      logical declaration is spread out across multiple places.  The most
+      obvious example is the "extend" block again -- there may be multiple
+      extend blocks in the same scope, each of which will have the same path.
+      - A location's span is not always a subset of its parent's span.  For
+      example, the "extendee" of an extension declaration appears at the
+      beginning of the "extend" block and is shared by all extensions within
+      the block.
+      - Just because a location's span is a subset of some other location's span
+      does not mean that it is a descendant.  For example, a "group" defines
+      both a type and a field in a single declaration.  Thus, the locations
+      corresponding to the type and field and their components will overlap.
+      - Code which tries to interpret locations should probably be designed to
+      ignore those that it doesn't understand, as more types of locations could
+      be recorded in the future.
       *)
 
       val make: ?location:Location.t list -> unit -> t
@@ -1415,21 +1437,21 @@ module rec Google : sig
     end
 
     (**
-       Describes the relationship between generated code and its original source
-       file. A GeneratedCodeInfo message is associated with only one generated
-       source file, but may contain references to different source .proto files.
+      Describes the relationship between generated code and its original source
+      file. A GeneratedCodeInfo message is associated with only one generated
+      source file, but may contain references to different source .proto files.
     *)
     and GeneratedCodeInfo : sig
       module rec Annotation : sig
         type t = {
         path: int list;(** Identifies the element in the original source .proto file. This field
-         is formatted the same as SourceCodeInfo.Location.path. *)
+        is formatted the same as SourceCodeInfo.Location.path. *)
         source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
         begin': int option;(** Identifies the starting offset in bytes in the generated code
-         that relates to the identified object. *)
+        that relates to the identified object. *)
         end': int option;(** Identifies the ending offset in bytes in the generated code that
-         relates to the identified offset. The end offset should be one past
-         the last relevant byte (so the length of the text = end - begin). *)
+        relates to the identified offset. The end offset should be one past
+        the last relevant byte (so the length of the text = end - begin). *)
         }
         val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -1459,8 +1481,8 @@ module rec Google : sig
       end
       type t = (Annotation.t list)
       (**
-      @param annotation An Annotation connects some span of text in generated code to an element
-       of its generating .proto file.
+      An Annotation connects some span of text in generated code to an element
+      of its generating .proto file.
       *)
 
       val make: ?annotation:Annotation.t list -> unit -> t
@@ -1494,8 +1516,8 @@ end = struct
   module rec Protobuf : sig
 
     (**
-       The protocol compiler can output a FileDescriptorSet containing the .proto
-       files it parses.
+      The protocol compiler can output a FileDescriptorSet containing the .proto
+      files it parses.
     *)
     module rec FileDescriptorSet : sig
       type t = (FileDescriptorProto.t list)
@@ -1538,14 +1560,14 @@ end = struct
       extension: FieldDescriptorProto.t list;
       options: FileOptions.t option;
       source_code_info: SourceCodeInfo.t option;(** This field contains optional information about the original source code.
-       You may safely remove this entire field without harming runtime
-       functionality of the descriptors -- the information is needed only by
-       development tools. *)
+      You may safely remove this entire field without harming runtime
+      functionality of the descriptors -- the information is needed only by
+      development tools. *)
       public_dependency: int list;(** Indexes of the public imported files in the dependency list above. *)
       weak_dependency: int list;(** Indexes of the weak imported files in the dependency list.
-       For Google-internal migration only. Do not use. *)
+      For Google-internal migration only. Do not use. *)
       syntax: string option;(** The syntax of the proto file.
-       The supported values are "proto2" and "proto3". *)
+      The supported values are "proto2" and "proto3". *)
       }
       val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -1610,9 +1632,9 @@ end = struct
       end
 
       (**
-         Range of reserved tag numbers. Reserved tag numbers may not be used by
-         fields or extension ranges in the same message. Reserved ranges may
-         not overlap.
+        Range of reserved tag numbers. Reserved tag numbers may not be used by
+        fields or extension ranges in the same message. Reserved ranges may
+        not overlap.
       *)
       and ReservedRange : sig
         type t = {
@@ -1656,7 +1678,7 @@ end = struct
       oneof_decl: OneofDescriptorProto.t list;
       reserved_range: ReservedRange.t list;
       reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
-       A given name may only be reserved once. *)
+      A given name may only be reserved once. *)
       }
       val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -1722,20 +1744,20 @@ end = struct
         type t =
           | TYPE_DOUBLE
           (**
-             0 is reserved for errors.
-             Order is weird for historical reasons.
+            0 is reserved for errors.
+            Order is weird for historical reasons.
           *)
           | TYPE_FLOAT
           | TYPE_INT64
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+            negative values are likely.
           *)
           | TYPE_UINT64
           | TYPE_INT32
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+            negative values are likely.
           *)
           | TYPE_FIXED64
           | TYPE_FIXED32
@@ -1743,10 +1765,10 @@ end = struct
           | TYPE_STRING
           | TYPE_GROUP
           (**
-             Tag-delimited aggregate.
-             Group type is deprecated and not supported in proto3. However, Proto3
-             implementations should still be able to parse the group wire format and
-             treat group fields as unknown fields.
+            Tag-delimited aggregate.
+            Group type is deprecated and not supported in proto3. However, Proto3
+            implementations should still be able to parse the group wire format and
+            treat group fields as unknown fields.
           *)
           | TYPE_MESSAGE
           (** Length-delimited aggregate. *)
@@ -1793,48 +1815,48 @@ end = struct
       type t = {
       name: string option;
       extendee: string option;(** For extensions, this is the name of the type being extended.  It is
-       resolved in the same manner as type_name. *)
+      resolved in the same manner as type_name. *)
       number: int option;
       label: Label.t option;
       type': Type.t option;(** If type_name is set, this need not be set.  If both this and type_name
-       are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
+      are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
       type_name: string option;(** For message and enum types, this is the name of the type.  If the name
-       starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-       rules are used to find the type (i.e. first the nested types within this
-       message are searched, then within the parent, on up to the root
-       namespace). *)
+      starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+      rules are used to find the type (i.e. first the nested types within this
+      message are searched, then within the parent, on up to the root
+      namespace). *)
       default_value: string option;(** For numeric types, contains the original text representation of the value.
-       For booleans, "true" or "false".
-       For strings, contains the default text contents (not escaped in any way).
-       For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
+      For booleans, "true" or "false".
+      For strings, contains the default text contents (not escaped in any way).
+      For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
       options: FieldOptions.t option;
       oneof_index: int option;(** If set, gives the index of a oneof in the containing type's oneof_decl
-       list.  This field is a member of that oneof. *)
+      list.  This field is a member of that oneof. *)
       json_name: string option;(** JSON name of this field. The value is set by protocol compiler. If the
-       user has set a "json_name" option on this field, that option's value
-       will be used. Otherwise, it's deduced from the field's name by converting
-       it to camelCase. *)
+      user has set a "json_name" option on this field, that option's value
+      will be used. Otherwise, it's deduced from the field's name by converting
+      it to camelCase. *)
       proto3_optional: bool option;(** If true, this is a proto3 "optional". When a proto3 field is optional, it
-       tracks presence regardless of field type.
+      tracks presence regardless of field type.
 
-       When proto3_optional is true, this field must be belong to a oneof to
-       signal to old proto3 clients that presence is tracked for this field. This
-       oneof is known as a "synthetic" oneof, and this field must be its sole
-       member (each proto3 optional field gets its own synthetic oneof). Synthetic
-       oneofs exist in the descriptor only, and do not generate any API. Synthetic
-       oneofs must be ordered after all "real" oneofs.
+      When proto3_optional is true, this field must be belong to a oneof to
+      signal to old proto3 clients that presence is tracked for this field. This
+      oneof is known as a "synthetic" oneof, and this field must be its sole
+      member (each proto3 optional field gets its own synthetic oneof). Synthetic
+      oneofs exist in the descriptor only, and do not generate any API. Synthetic
+      oneofs must be ordered after all "real" oneofs.
 
-       For message fields, proto3_optional doesn't create any semantic change,
-       since non-repeated message fields always track presence. However it still
-       indicates the semantic detail of whether the user wrote "optional" or not.
-       This can be useful for round-tripping the .proto file. For consistency we
-       give message fields a synthetic oneof also, even though it is not required
-       to track presence. This is especially important because the parser can't
-       tell if a field is a message or an enum, so it must always create a
-       synthetic oneof.
+      For message fields, proto3_optional doesn't create any semantic change,
+      since non-repeated message fields always track presence. However it still
+      indicates the semantic detail of whether the user wrote "optional" or not.
+      This can be useful for round-tripping the .proto file. For consistency we
+      give message fields a synthetic oneof also, even though it is not required
+      to track presence. This is especially important because the parser can't
+      tell if a field is a message or an enum, so it must always create a
+      synthetic oneof.
 
-       Proto2 optional fields do not set this flag, because they already indicate
-       optional with `LABEL_OPTIONAL`. *)
+      Proto2 optional fields do not set this flag, because they already indicate
+      optional with `LABEL_OPTIONAL`. *)
       }
       val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -1900,12 +1922,12 @@ end = struct
     and EnumDescriptorProto : sig
 
       (**
-         Range of reserved numeric values. Reserved values may not be used by
-         entries in the same enum. Reserved ranges may not overlap.
+        Range of reserved numeric values. Reserved values may not be used by
+        entries in the same enum. Reserved ranges may not overlap.
 
-         Note that this is distinct from DescriptorProto.ReservedRange in that it
-         is inclusive such that it can appropriately represent the entire int32
-         domain.
+        Note that this is distinct from DescriptorProto.ReservedRange in that it
+        is inclusive such that it can appropriately represent the entire int32
+        domain.
       *)
       module rec EnumReservedRange : sig
         type t = {
@@ -1943,10 +1965,10 @@ end = struct
       value: EnumValueDescriptorProto.t list;
       options: EnumOptions.t option;
       reserved_range: EnumReservedRange.t list;(** Range of reserved numeric values. Reserved numeric values may not be used
-       by enum values in the same enum declaration. Reserved ranges may not
-       overlap. *)
+      by enum values in the same enum declaration. Reserved ranges may not
+      overlap. *)
       reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
-       be reserved once. *)
+      be reserved once. *)
       }
       val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -2048,7 +2070,7 @@ end = struct
       type t = {
       name: string option;
       input_type: string option;(** Input and output type names.  These are resolved in the same way as
-       FieldDescriptorProto.type_name, but must refer to a message type. *)
+      FieldDescriptorProto.type_name, but must refer to a message type. *)
       output_type: string option;
       options: MethodOptions.t option;
       client_streaming: bool;(** Identifies if client streams multiple client messages *)
@@ -2089,9 +2111,10 @@ end = struct
           (** Generate complete code for parsing, serialization, *)
           | CODE_SIZE
           (**
-             etc.
+            etc.
 
-             Use ReflectionOps to implement these methods.
+
+            Use ReflectionOps to implement these methods.
           *)
           | LITE_RUNTIME
           (** Generate code using MessageLite and the lite runtime. *)
@@ -2109,74 +2132,73 @@ end = struct
       end
       type t = {
       java_package: string option;(** Sets the Java package where classes generated from this .proto will be
-       placed.  By default, the proto package is used, but this is often
-       inappropriate because proto packages do not normally start with backwards
-       domain names. *)
+      placed.  By default, the proto package is used, but this is often
+      inappropriate because proto packages do not normally start with backwards
+      domain names. *)
       java_outer_classname: string option;(** Controls the name of the wrapper Java class generated for the .proto file.
-       That class will always contain the .proto file's getDescriptor() method as
-       well as any top-level extensions defined in the .proto file.
-       If java_multiple_files is disabled, then all the other classes from the
-       .proto file will be nested inside the single wrapper outer class. *)
+      That class will always contain the .proto file's getDescriptor() method as
+      well as any top-level extensions defined in the .proto file.
+      If java_multiple_files is disabled, then all the other classes from the
+      .proto file will be nested inside the single wrapper outer class. *)
       optimize_for: OptimizeMode.t;(** Clients can define custom options in extensions of this message.
-       See the documentation for the "Options" section above. *)
+      See the documentation for the "Options" section above. *)
       java_multiple_files: bool;(** If enabled, then the Java code generator will generate a separate .java
-       file for each top-level message, enum, and service defined in the .proto
-       file.  Thus, these types will *not* be nested inside the wrapper class
-       named by java_outer_classname.  However, the wrapper class will still be
-       generated to contain the file's getDescriptor() method as well as any
-       top-level extensions defined in the file. *)
+      file for each top-level message, enum, and service defined in the .proto
+      file.  Thus, these types will *not* be nested inside the wrapper class
+      named by java_outer_classname.  However, the wrapper class will still be
+      generated to contain the file's getDescriptor() method as well as any
+      top-level extensions defined in the file. *)
       go_package: string option;(** Sets the Go package where structs generated from this .proto will be
-       placed. If omitted, the Go package will be derived from the following:
-         - The basename of the package import path, if provided.
-         - Otherwise, the package statement in the .proto file, if present.
-         - Otherwise, the basename of the .proto file, without extension. *)
+      placed. If omitted, the Go package will be derived from the following:
+      - The basename of the package import path, if provided.
+      - Otherwise, the package statement in the .proto file, if present.
+      - Otherwise, the basename of the .proto file, without extension. *)
       cc_generic_services: bool;(** Should generic services be generated in each language?  "Generic" services
-       are not specific to any particular RPC system.  They are generated by the
-       main code generators in each language (without additional plugins).
-       Generic services were the only kind of service generation supported by
-       early versions of google.protobuf.
+      are not specific to any particular RPC system.  They are generated by the
+      main code generators in each language (without additional plugins).
+      Generic services were the only kind of service generation supported by
+      early versions of google.protobuf.
 
-       Generic services are now considered deprecated in favor of using plugins
-       that generate code specific to your particular RPC system.  Therefore,
-       these default to false.  Old code which depends on generic services should
-       explicitly set them to true. *)
+      Generic services are now considered deprecated in favor of using plugins
+      that generate code specific to your particular RPC system.  Therefore,
+      these default to false.  Old code which depends on generic services should
+      explicitly set them to true. *)
       java_generic_services: bool;
       py_generic_services: bool;
-      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"];(** This option does nothing.
-      @deprecated deprecated in proto file *)
+      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Marked as deprecated in the .proto file"];(** This option does nothing. *)
       deprecated: bool;(** Is this file deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for everything in the file, or it will be completely ignored; in the very
-       least, this is a formalization for deprecating files. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for everything in the file, or it will be completely ignored; in the very
+      least, this is a formalization for deprecating files. *)
       java_string_check_utf8: bool;(** If set true, then the Java2 code generator will generate code that
-       throws an exception whenever an attempt is made to assign a non-UTF-8
-       byte sequence to a string field.
-       Message reflection will do the same.
-       However, an extension field still accepts non-UTF-8 byte sequences.
-       This option has no effect on when used with the lite runtime. *)
+      throws an exception whenever an attempt is made to assign a non-UTF-8
+      byte sequence to a string field.
+      Message reflection will do the same.
+      However, an extension field still accepts non-UTF-8 byte sequences.
+      This option has no effect on when used with the lite runtime. *)
       cc_enable_arenas: bool;(** Enables the use of arenas for the proto messages in this file. This applies
-       only to generated classes for C++. *)
+      only to generated classes for C++. *)
       objc_class_prefix: string option;(** Sets the objective c class prefix which is prepended to all objective c
-       generated classes from this .proto. There is no default. *)
+      generated classes from this .proto. There is no default. *)
       csharp_namespace: string option;(** Namespace for generated classes; defaults to the package. *)
       swift_prefix: string option;(** By default Swift generators will take the proto package and CamelCase it
-       replacing '.' with underscore and use that to prefix the types/symbols
-       defined. When this options is provided, they will use this value instead
-       to prefix the types/symbols defined. *)
+      replacing '.' with underscore and use that to prefix the types/symbols
+      defined. When this options is provided, they will use this value instead
+      to prefix the types/symbols defined. *)
       php_class_prefix: string option;(** Sets the php class prefix which is prepended to all php generated classes
-       from this .proto. Default is empty. *)
+      from this .proto. Default is empty. *)
       php_namespace: string option;(** Use this option to change the namespace of php generated classes. Default
-       is empty. When this option is empty, the package name will be used for
-       determining the namespace. *)
+      is empty. When this option is empty, the package name will be used for
+      determining the namespace. *)
       php_generic_services: bool;
       php_metadata_namespace: string option;(** Use this option to change the namespace of php generated metadata classes.
-       Default is empty. When this option is empty, the proto file name will be
-       used for determining the namespace. *)
+      Default is empty. When this option is empty, the proto file name will be
+      used for determining the namespace. *)
       ruby_package: string option;(** Use this option to change the package of ruby generated classes. Default
-       is empty. When this option is not set, the package name will be used for
-       determining the ruby package. *)
+      is empty. When this option is not set, the package name will be used for
+      determining the ruby package. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here.
-       See the documentation for the "Options" section above. *)
+      See the documentation for the "Options" section above. *)
       extensions': Runtime'.Extensions.t;
       }
       val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
@@ -2208,51 +2230,56 @@ end = struct
     and MessageOptions : sig
       type t = {
       message_set_wire_format: bool;(** Set true to use the old proto1 MessageSet wire format for extensions.
-       This is provided for backwards-compatibility with the MessageSet wire
-       format.  You should not use this for any other reason:  It's less
-       efficient, has fewer features, and is more complicated.
+      This is provided for backwards-compatibility with the MessageSet wire
+      format.  You should not use this for any other reason:  It's less
+      efficient, has fewer features, and is more complicated.
 
-       The message must be defined exactly as follows:
-         message Foo \{
+      The message must be defined exactly as follows:
+      {v
+         message Foo {
            option message_set_wire_format = true;
            extensions 4 to max;
-         \}
-       Note that the message cannot have any defined fields; MessageSets only
-       have extensions.
+         }
+      v}
+      Note that the message cannot have any defined fields; MessageSets only
+      have extensions.
 
-       All extensions of your type must be singular messages; e.g. they cannot
-       be int32s, enums, or repeated messages.
+      All extensions of your type must be singular messages; e.g. they cannot
+      be int32s, enums, or repeated messages.
 
-       Because this is an option, the above two restrictions are not enforced by
-       the protocol compiler. *)
+      Because this is an option, the above two restrictions are not enforced by
+      the protocol compiler. *)
       no_standard_descriptor_accessor: bool;(** Disables the generation of the standard "descriptor()" accessor, which can
-       conflict with a field of the same name.  This is meant to make migration
-       from proto1 easier; new code should avoid fields named "descriptor". *)
+      conflict with a field of the same name.  This is meant to make migration
+      from proto1 easier; new code should avoid fields named "descriptor". *)
       deprecated: bool;(** Is this message deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the message, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating messages. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the message, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating messages. *)
       map_entry: bool option;(** Whether the message is an automatically generated map entry type for the
-       maps field.
+      maps field.
 
-       For maps fields:
+      For maps fields:
+      {v
            map<KeyType, ValueType> map_field = 1;
-       The parsed descriptor looks like:
-           message MapFieldEntry \{
+      v}
+      The parsed descriptor looks like:
+      {v
+           message MapFieldEntry {
                option map_entry = true;
                optional KeyType key = 1;
                optional ValueType value = 2;
-           \}
+           }
            repeated MapFieldEntry map_field = 1;
+      v}
+      Implementations may choose not to generate the map_entry=true message, but
+      use a native map in the target language to hold the keys and values.
+      The reflection APIs in such implementations still need to work as
+      if the field is a repeated message field.
 
-       Implementations may choose not to generate the map_entry=true message, but
-       use a native map in the target language to hold the keys and values.
-       The reflection APIs in such implementations still need to work as
-       if the field is a repeated message field.
-
-       NOTE: Do not set the option in .proto files. Always use the maps syntax
-       instead. The option should only be implicitly set by the proto compiler
-       parser. *)
+      NOTE: Do not set the option in .proto files. Always use the maps syntax
+      instead. The option should only be implicitly set by the proto compiler
+      parser. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -2323,64 +2350,64 @@ end = struct
       end
       type t = {
       ctype: CType.t;(** The ctype option instructs the C++ code generator to use a different
-       representation of the field than it normally would.  See the specific
-       options below.  This option is not yet implemented in the open source
-       release -- sorry, we'll try to include it in a future version! *)
+      representation of the field than it normally would.  See the specific
+      options below.  This option is not yet implemented in the open source
+      release -- sorry, we'll try to include it in a future version! *)
       packed: bool option;(** The packed option can be enabled for repeated primitive fields to enable
-       a more efficient representation on the wire. Rather than repeatedly
-       writing the tag and type for each element, the entire array is encoded as
-       a single length-delimited blob. In proto3, only explicit setting it to
-       false will avoid using packed encoding. *)
+      a more efficient representation on the wire. Rather than repeatedly
+      writing the tag and type for each element, the entire array is encoded as
+      a single length-delimited blob. In proto3, only explicit setting it to
+      false will avoid using packed encoding. *)
       deprecated: bool;(** Clients can define custom options in extensions of this message. See above. *)
       lazy': bool;(** Should this field be parsed lazily?  Lazy applies only to message-type
-       fields.  It means that when the outer message is initially parsed, the
-       inner message's contents will not be parsed but instead stored in encoded
-       form.  The inner message will actually be parsed when it is first accessed.
+      fields.  It means that when the outer message is initially parsed, the
+      inner message's contents will not be parsed but instead stored in encoded
+      form.  The inner message will actually be parsed when it is first accessed.
 
-       This is only a hint.  Implementations are free to choose whether to use
-       eager or lazy parsing regardless of the value of this option.  However,
-       setting this option true suggests that the protocol author believes that
-       using lazy parsing on this field is worth the additional bookkeeping
-       overhead typically needed to implement it.
+      This is only a hint.  Implementations are free to choose whether to use
+      eager or lazy parsing regardless of the value of this option.  However,
+      setting this option true suggests that the protocol author believes that
+      using lazy parsing on this field is worth the additional bookkeeping
+      overhead typically needed to implement it.
 
-       This option does not affect the public interface of any generated code;
-       all method signatures remain the same.  Furthermore, thread-safety of the
-       interface is not affected by this option; const methods remain safe to
-       call from multiple threads concurrently, while non-const methods continue
-       to require exclusive access.
+      This option does not affect the public interface of any generated code;
+      all method signatures remain the same.  Furthermore, thread-safety of the
+      interface is not affected by this option; const methods remain safe to
+      call from multiple threads concurrently, while non-const methods continue
+      to require exclusive access.
 
 
-       Note that implementations may choose not to check required fields within
-       a lazy sub-message.  That is, calling IsInitialized() on the outer message
-       may return true even if the inner message has missing required fields.
-       This is necessary because otherwise the inner message would have to be
-       parsed in order to perform the check, defeating the purpose of lazy
-       parsing.  An implementation which chooses not to check required fields
-       must be consistent about it.  That is, for any particular sub-message, the
-       implementation must either *always* check its required fields, or *never*
-       check its required fields, regardless of whether or not the message has
-       been parsed.
+      Note that implementations may choose not to check required fields within
+      a lazy sub-message.  That is, calling IsInitialized() on the outer message
+      may return true even if the inner message has missing required fields.
+      This is necessary because otherwise the inner message would have to be
+      parsed in order to perform the check, defeating the purpose of lazy
+      parsing.  An implementation which chooses not to check required fields
+      must be consistent about it.  That is, for any particular sub-message, the
+      implementation must either *always* check its required fields, or *never*
+      check its required fields, regardless of whether or not the message has
+      been parsed.
 
-       As of 2021, lazy does no correctness checks on the byte stream during
-       parsing.  This may lead to crashes if and when an invalid byte stream is
-       finally parsed upon access.
+      As of 2021, lazy does no correctness checks on the byte stream during
+      parsing.  This may lead to crashes if and when an invalid byte stream is
+      finally parsed upon access.
 
-       TODO(b/211906113):  Enable validation on lazy fields. *)
+      TODO(b/211906113):  Enable validation on lazy fields. *)
       jstype: JSType.t;(** The jstype option determines the JavaScript type used for values of the
-       field.  The option is permitted only for 64 bit integral and fixed types
-       (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
-       is represented as JavaScript string, which avoids loss of precision that
-       can happen when a large value is converted to a floating point JavaScript.
-       Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
-       use the JavaScript "number" type.  The behavior of the default option
-       JS_NORMAL is implementation dependent.
+      field.  The option is permitted only for 64 bit integral and fixed types
+      (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+      is represented as JavaScript string, which avoids loss of precision that
+      can happen when a large value is converted to a floating point JavaScript.
+      Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+      use the JavaScript "number" type.  The behavior of the default option
+      JS_NORMAL is implementation dependent.
 
-       This option is an enum to permit additional types to be added, e.g.
-       goog.math.Integer. *)
+      This option is an enum to permit additional types to be added, e.g.
+      goog.math.Integer. *)
       weak: bool;(** For Google-internal migration only. Do not use. *)
       unverified_lazy: bool;(** unverified_lazy does no correctness checks on the byte stream. This should
-       only be used where lazy with verification is prohibitive for performance
-       reasons. *)
+      only be used where lazy with verification is prohibitive for performance
+      reasons. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -2444,11 +2471,11 @@ end = struct
     and EnumOptions : sig
       type t = {
       allow_alias: bool option;(** Set this option to true to allow mapping different tag names to the same
-       value. *)
+      value. *)
       deprecated: bool;(** Is this enum deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the enum, or it will be completely ignored; in the very least, this
-       is a formalization for deprecating enums. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the enum, or it will be completely ignored; in the very least, this
+      is a formalization for deprecating enums. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -2481,9 +2508,9 @@ end = struct
     and EnumValueOptions : sig
       type t = {
       deprecated: bool;(** Is this enum value deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the enum value, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating enum values. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the enum value, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating enum values. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -2516,9 +2543,9 @@ end = struct
     and ServiceOptions : sig
       type t = {
       deprecated: bool;(** Is this service deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the service, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating services. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the service, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating services. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -2551,9 +2578,9 @@ end = struct
     and MethodOptions : sig
 
       (**
-         Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-         or neither? HTTP based RPC implementation may choose GET verb for safe
-         methods, and PUT verb for idempotent methods instead of the default POST.
+        Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+        or neither? HTTP based RPC implementation may choose GET verb for safe
+        methods, and PUT verb for idempotent methods instead of the default POST.
       *)
       module rec IdempotencyLevel : sig
         type t =
@@ -2576,9 +2603,9 @@ end = struct
       end
       type t = {
       deprecated: bool;(** Is this method deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the method, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating methods. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the method, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating methods. *)
       idempotency_level: IdempotencyLevel.t;
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
@@ -2611,21 +2638,21 @@ end = struct
     end
 
     (**
-       A message representing a option the parser does not recognize. This only
-       appears in options protos created by the compiler::Parser class.
-       DescriptorPool resolves these when building Descriptor objects. Therefore,
-       options protos in descriptor objects (e.g. returned by Descriptor::options(),
-       or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-       in them.
+      A message representing a option the parser does not recognize. This only
+      appears in options protos created by the compiler::Parser class.
+      DescriptorPool resolves these when building Descriptor objects. Therefore,
+      options protos in descriptor objects (e.g. returned by Descriptor::options(),
+      or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+      in them.
     *)
     and UninterpretedOption : sig
 
       (**
-         The name of the uninterpreted option.  Each string represents a segment in
-         a dot-separated name.  is_extension is true iff a segment represents an
-         extension (denoted with parentheses in options specs in .proto files).
-         E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
-         "foo.(bar.baz).moo".
+        The name of the uninterpreted option.  Each string represents a segment in
+        a dot-separated name.  is_extension is true iff a segment represents an
+        extension (denoted with parentheses in options specs in .proto files).
+        E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
+        "foo.(bar.baz).moo".
       *)
       module rec NamePart : sig
         type t = {
@@ -2661,7 +2688,7 @@ end = struct
       type t = {
       name: NamePart.t list;
       identifier_value: string option;(** The value of the uninterpreted option, in whatever type the tokenizer
-       identified it as during parsing. Exactly one of these should be set. *)
+      identified it as during parsing. Exactly one of these should be set. *)
       positive_int_value: int option;
       negative_int_value: int option;
       double_value: float option;
@@ -2696,59 +2723,70 @@ end = struct
     end
 
     (**
-       Encapsulates information about the original source file from which a
-       FileDescriptorProto was generated.
+      Encapsulates information about the original source file from which a
+      FileDescriptorProto was generated.
     *)
     and SourceCodeInfo : sig
       module rec Location : sig
         type t = {
         path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
-         location.
+        location.
 
-         Each element is a field number or an index.  They form a path from
-         the root FileDescriptorProto to the place where the definition occurs.
-         For example, this path:
-           \[ 4, 3, 2, 7, 1 \]
-         refers to:
+        Each element is a field number or an index.  They form a path from
+        the root FileDescriptorProto to the place where the definition occurs.
+        For example, this path:
+        {v
+           [ 4, 3, 2, 7, 1 ]
+        v}
+        refers to:
+        {v
            file.message_type(3)  // 4, 3
                .field(7)         // 2, 7
                .name()           // 1
-         This is because FileDescriptorProto.message_type has field number 4:
+        v}
+        This is because FileDescriptorProto.message_type has field number 4:
+        {v
            repeated DescriptorProto message_type = 4;
-         and DescriptorProto.field has field number 2:
+        v}
+        and DescriptorProto.field has field number 2:
+        {v
            repeated FieldDescriptorProto field = 2;
-         and FieldDescriptorProto.name has field number 1:
+        v}
+        and FieldDescriptorProto.name has field number 1:
+        {v
            optional string name = 1;
-
-         Thus, the above path gives the location of a field name.  If we removed
-         the last element:
-           \[ 4, 3, 2, 7 \]
-         this path refers to the whole field declaration (from the beginning
-         of the label to the terminating semicolon). *)
+        v}
+        Thus, the above path gives the location of a field name.  If we removed
+        the last element:
+        {v
+           [ 4, 3, 2, 7 ]
+        v}
+        this path refers to the whole field declaration (from the beginning
+        of the label to the terminating semicolon). *)
         span: int list;(** Always has exactly three or four elements: start line, start column,
-         end line (optional, otherwise assumed same as start line), end column.
-         These are packed into a single field for efficiency.  Note that line
-         and column numbers are zero-based -- typically you will want to add
-         1 to each before displaying to a user. *)
+        end line (optional, otherwise assumed same as start line), end column.
+        These are packed into a single field for efficiency.  Note that line
+        and column numbers are zero-based -- typically you will want to add
+        1 to each before displaying to a user. *)
         leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
-         comments appearing before and after the declaration which appear to be
-         attached to the declaration.
+        comments appearing before and after the declaration which appear to be
+        attached to the declaration.
 
-         A series of line comments appearing on consecutive lines, with no other
-         tokens appearing on those lines, will be treated as a single comment.
+        A series of line comments appearing on consecutive lines, with no other
+        tokens appearing on those lines, will be treated as a single comment.
 
-         leading_detached_comments will keep paragraphs of comments that appear
-         before (but not connected to) the current element. Each paragraph,
-         separated by empty lines, will be one comment element in the repeated
-         field.
+        leading_detached_comments will keep paragraphs of comments that appear
+        before (but not connected to) the current element. Each paragraph,
+        separated by empty lines, will be one comment element in the repeated
+        field.
 
-         Only the comment content is provided; comment markers (e.g. //) are
-         stripped out.  For block comments, leading whitespace and an asterisk
-         will be stripped from the beginning of each line other than the first.
-         Newlines are included in the output.
+        Only the comment content is provided; comment markers (e.g. //) are
+        stripped out.  For block comments, leading whitespace and an asterisk
+        will be stripped from the beginning of each line other than the first.
+        Newlines are included in the output.
 
-         Examples:
-
+        Examples:
+        {v
            optional int32 foo = 1;  // Comment attached to foo.
            // Comment attached to bar.
            optional int32 bar = 2;
@@ -2776,7 +2814,8 @@ end = struct
             * grault. */
            optional int32 grault = 6;
 
-           // ignored detached comments. *)
+           // ignored detached comments.
+        v} *)
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
@@ -2808,49 +2847,54 @@ end = struct
       end
       type t = (Location.t list)
       (**
-      @param location A Location identifies a piece of source code in a .proto file which
-       corresponds to a particular definition.  This information is intended
-       to be useful to IDEs, code indexers, documentation generators, and similar
-       tools.
+      A Location identifies a piece of source code in a .proto file which
+      corresponds to a particular definition.  This information is intended
+      to be useful to IDEs, code indexers, documentation generators, and similar
+      tools.
 
-       For example, say we have a file like:
-         message Foo \{
+      For example, say we have a file like:
+      {v
+         message Foo {
            optional string foo = 1;
-         \}
-       Let's look at just the field definition:
+         }
+      v}
+      Let's look at just the field definition:
+      {v
          optional string foo = 1;
          ^       ^^     ^^  ^  ^^^
          a       bc     de  f  ghi
-       We have the following locations:
+      v}
+      We have the following locations:
+      {v
          span   path               represents
-         \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
-         \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
-         \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
-         \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
-         \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
-
-       Notes:
-       - A location may refer to a repeated field itself (i.e. not to any
-         particular index within it).  This is used whenever a set of elements are
-         logically enclosed in a single code segment.  For example, an entire
-         extend block (possibly containing multiple extension definitions) will
-         have an outer location whose path refers to the "extensions" repeated
-         field without an index.
-       - Multiple locations may have the same path.  This happens when a single
-         logical declaration is spread out across multiple places.  The most
-         obvious example is the "extend" block again -- there may be multiple
-         extend blocks in the same scope, each of which will have the same path.
-       - A location's span is not always a subset of its parent's span.  For
-         example, the "extendee" of an extension declaration appears at the
-         beginning of the "extend" block and is shared by all extensions within
-         the block.
-       - Just because a location's span is a subset of some other location's span
-         does not mean that it is a descendant.  For example, a "group" defines
-         both a type and a field in a single declaration.  Thus, the locations
-         corresponding to the type and field and their components will overlap.
-       - Code which tries to interpret locations should probably be designed to
-         ignore those that it doesn't understand, as more types of locations could
-         be recorded in the future.
+         [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+         [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+         [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+         [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+         [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+      v}
+      Notes:
+      - A location may refer to a repeated field itself (i.e. not to any
+      particular index within it).  This is used whenever a set of elements are
+      logically enclosed in a single code segment.  For example, an entire
+      extend block (possibly containing multiple extension definitions) will
+      have an outer location whose path refers to the "extensions" repeated
+      field without an index.
+      - Multiple locations may have the same path.  This happens when a single
+      logical declaration is spread out across multiple places.  The most
+      obvious example is the "extend" block again -- there may be multiple
+      extend blocks in the same scope, each of which will have the same path.
+      - A location's span is not always a subset of its parent's span.  For
+      example, the "extendee" of an extension declaration appears at the
+      beginning of the "extend" block and is shared by all extensions within
+      the block.
+      - Just because a location's span is a subset of some other location's span
+      does not mean that it is a descendant.  For example, a "group" defines
+      both a type and a field in a single declaration.  Thus, the locations
+      corresponding to the type and field and their components will overlap.
+      - Code which tries to interpret locations should probably be designed to
+      ignore those that it doesn't understand, as more types of locations could
+      be recorded in the future.
       *)
 
       val make: ?location:Location.t list -> unit -> t
@@ -2881,21 +2925,21 @@ end = struct
     end
 
     (**
-       Describes the relationship between generated code and its original source
-       file. A GeneratedCodeInfo message is associated with only one generated
-       source file, but may contain references to different source .proto files.
+      Describes the relationship between generated code and its original source
+      file. A GeneratedCodeInfo message is associated with only one generated
+      source file, but may contain references to different source .proto files.
     *)
     and GeneratedCodeInfo : sig
       module rec Annotation : sig
         type t = {
         path: int list;(** Identifies the element in the original source .proto file. This field
-         is formatted the same as SourceCodeInfo.Location.path. *)
+        is formatted the same as SourceCodeInfo.Location.path. *)
         source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
         begin': int option;(** Identifies the starting offset in bytes in the generated code
-         that relates to the identified object. *)
+        that relates to the identified object. *)
         end': int option;(** Identifies the ending offset in bytes in the generated code that
-         relates to the identified offset. The end offset should be one past
-         the last relevant byte (so the length of the text = end - begin). *)
+        relates to the identified offset. The end offset should be one past
+        the last relevant byte (so the length of the text = end - begin). *)
         }
         val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -2925,8 +2969,8 @@ end = struct
       end
       type t = (Annotation.t list)
       (**
-      @param annotation An Annotation connects some span of text in generated code to an element
-       of its generating .proto file.
+      An Annotation connects some span of text in generated code to an element
+      of its generating .proto file.
       *)
 
       val make: ?annotation:Annotation.t list -> unit -> t
@@ -3021,14 +3065,14 @@ end = struct
       extension: FieldDescriptorProto.t list;
       options: FileOptions.t option;
       source_code_info: SourceCodeInfo.t option;(** This field contains optional information about the original source code.
-       You may safely remove this entire field without harming runtime
-       functionality of the descriptors -- the information is needed only by
-       development tools. *)
+      You may safely remove this entire field without harming runtime
+      functionality of the descriptors -- the information is needed only by
+      development tools. *)
       public_dependency: int list;(** Indexes of the public imported files in the dependency list above. *)
       weak_dependency: int list;(** Indexes of the weak imported files in the dependency list.
-       For Google-internal migration only. Do not use. *)
+      For Google-internal migration only. Do not use. *)
       syntax: string option;(** The syntax of the proto file.
-       The supported values are "proto2" and "proto3". *)
+      The supported values are "proto2" and "proto3". *)
       }
       val make: ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -3068,14 +3112,14 @@ end = struct
       extension: FieldDescriptorProto.t list;
       options: FileOptions.t option;
       source_code_info: SourceCodeInfo.t option;(** This field contains optional information about the original source code.
-       You may safely remove this entire field without harming runtime
-       functionality of the descriptors -- the information is needed only by
-       development tools. *)
+      You may safely remove this entire field without harming runtime
+      functionality of the descriptors -- the information is needed only by
+      development tools. *)
       public_dependency: int list;(** Indexes of the public imported files in the dependency list above. *)
       weak_dependency: int list;(** Indexes of the weak imported files in the dependency list.
-       For Google-internal migration only. Do not use. *)
+      For Google-internal migration only. Do not use. *)
       syntax: string option;(** The syntax of the proto file.
-       The supported values are "proto2" and "proto3". *)
+      The supported values are "proto2" and "proto3". *)
       }
       type make_t = ?name:string -> ?package:string -> ?dependency:string list -> ?message_type:DescriptorProto.t list -> ?enum_type:EnumDescriptorProto.t list -> ?service:ServiceDescriptorProto.t list -> ?extension:FieldDescriptorProto.t list -> ?options:FileOptions.t -> ?source_code_info:SourceCodeInfo.t -> ?public_dependency:int list -> ?weak_dependency:int list -> ?syntax:string -> unit -> t
       let make ?name ?package ?(dependency = []) ?(message_type = []) ?(enum_type = []) ?(service = []) ?(extension = []) ?options ?source_code_info ?(public_dependency = []) ?(weak_dependency = []) ?syntax () = { name; package; dependency; message_type; enum_type; service; extension; options; source_code_info; public_dependency; weak_dependency; syntax }
@@ -3159,9 +3203,9 @@ end = struct
       end
 
       (**
-         Range of reserved tag numbers. Reserved tag numbers may not be used by
-         fields or extension ranges in the same message. Reserved ranges may
-         not overlap.
+        Range of reserved tag numbers. Reserved tag numbers may not be used by
+        fields or extension ranges in the same message. Reserved ranges may
+        not overlap.
       *)
       and ReservedRange : sig
         type t = {
@@ -3205,7 +3249,7 @@ end = struct
       oneof_decl: OneofDescriptorProto.t list;
       reserved_range: ReservedRange.t list;
       reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
-       A given name may only be reserved once. *)
+      A given name may only be reserved once. *)
       }
       val make: ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -3378,7 +3422,7 @@ end = struct
       oneof_decl: OneofDescriptorProto.t list;
       reserved_range: ReservedRange.t list;
       reserved_name: string list;(** Reserved field names, which may not be used by fields in the same message.
-       A given name may only be reserved once. *)
+      A given name may only be reserved once. *)
       }
       type make_t = ?name:string -> ?field:FieldDescriptorProto.t list -> ?nested_type:t list -> ?enum_type:EnumDescriptorProto.t list -> ?extension_range:ExtensionRange.t list -> ?extension:FieldDescriptorProto.t list -> ?options:MessageOptions.t -> ?oneof_decl:OneofDescriptorProto.t list -> ?reserved_range:ReservedRange.t list -> ?reserved_name:string list -> unit -> t
       let make ?name ?(field = []) ?(nested_type = []) ?(enum_type = []) ?(extension_range = []) ?(extension = []) ?options ?(oneof_decl = []) ?(reserved_range = []) ?(reserved_name = []) () = { name; field; nested_type; enum_type; extension_range; extension; options; oneof_decl; reserved_range; reserved_name }
@@ -3491,20 +3535,20 @@ end = struct
         type t =
           | TYPE_DOUBLE
           (**
-             0 is reserved for errors.
-             Order is weird for historical reasons.
+            0 is reserved for errors.
+            Order is weird for historical reasons.
           *)
           | TYPE_FLOAT
           | TYPE_INT64
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+            negative values are likely.
           *)
           | TYPE_UINT64
           | TYPE_INT32
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+            negative values are likely.
           *)
           | TYPE_FIXED64
           | TYPE_FIXED32
@@ -3512,10 +3556,10 @@ end = struct
           | TYPE_STRING
           | TYPE_GROUP
           (**
-             Tag-delimited aggregate.
-             Group type is deprecated and not supported in proto3. However, Proto3
-             implementations should still be able to parse the group wire format and
-             treat group fields as unknown fields.
+            Tag-delimited aggregate.
+            Group type is deprecated and not supported in proto3. However, Proto3
+            implementations should still be able to parse the group wire format and
+            treat group fields as unknown fields.
           *)
           | TYPE_MESSAGE
           (** Length-delimited aggregate. *)
@@ -3562,48 +3606,48 @@ end = struct
       type t = {
       name: string option;
       extendee: string option;(** For extensions, this is the name of the type being extended.  It is
-       resolved in the same manner as type_name. *)
+      resolved in the same manner as type_name. *)
       number: int option;
       label: Label.t option;
       type': Type.t option;(** If type_name is set, this need not be set.  If both this and type_name
-       are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
+      are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
       type_name: string option;(** For message and enum types, this is the name of the type.  If the name
-       starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-       rules are used to find the type (i.e. first the nested types within this
-       message are searched, then within the parent, on up to the root
-       namespace). *)
+      starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+      rules are used to find the type (i.e. first the nested types within this
+      message are searched, then within the parent, on up to the root
+      namespace). *)
       default_value: string option;(** For numeric types, contains the original text representation of the value.
-       For booleans, "true" or "false".
-       For strings, contains the default text contents (not escaped in any way).
-       For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
+      For booleans, "true" or "false".
+      For strings, contains the default text contents (not escaped in any way).
+      For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
       options: FieldOptions.t option;
       oneof_index: int option;(** If set, gives the index of a oneof in the containing type's oneof_decl
-       list.  This field is a member of that oneof. *)
+      list.  This field is a member of that oneof. *)
       json_name: string option;(** JSON name of this field. The value is set by protocol compiler. If the
-       user has set a "json_name" option on this field, that option's value
-       will be used. Otherwise, it's deduced from the field's name by converting
-       it to camelCase. *)
+      user has set a "json_name" option on this field, that option's value
+      will be used. Otherwise, it's deduced from the field's name by converting
+      it to camelCase. *)
       proto3_optional: bool option;(** If true, this is a proto3 "optional". When a proto3 field is optional, it
-       tracks presence regardless of field type.
+      tracks presence regardless of field type.
 
-       When proto3_optional is true, this field must be belong to a oneof to
-       signal to old proto3 clients that presence is tracked for this field. This
-       oneof is known as a "synthetic" oneof, and this field must be its sole
-       member (each proto3 optional field gets its own synthetic oneof). Synthetic
-       oneofs exist in the descriptor only, and do not generate any API. Synthetic
-       oneofs must be ordered after all "real" oneofs.
+      When proto3_optional is true, this field must be belong to a oneof to
+      signal to old proto3 clients that presence is tracked for this field. This
+      oneof is known as a "synthetic" oneof, and this field must be its sole
+      member (each proto3 optional field gets its own synthetic oneof). Synthetic
+      oneofs exist in the descriptor only, and do not generate any API. Synthetic
+      oneofs must be ordered after all "real" oneofs.
 
-       For message fields, proto3_optional doesn't create any semantic change,
-       since non-repeated message fields always track presence. However it still
-       indicates the semantic detail of whether the user wrote "optional" or not.
-       This can be useful for round-tripping the .proto file. For consistency we
-       give message fields a synthetic oneof also, even though it is not required
-       to track presence. This is especially important because the parser can't
-       tell if a field is a message or an enum, so it must always create a
-       synthetic oneof.
+      For message fields, proto3_optional doesn't create any semantic change,
+      since non-repeated message fields always track presence. However it still
+      indicates the semantic detail of whether the user wrote "optional" or not.
+      This can be useful for round-tripping the .proto file. For consistency we
+      give message fields a synthetic oneof also, even though it is not required
+      to track presence. This is especially important because the parser can't
+      tell if a field is a message or an enum, so it must always create a
+      synthetic oneof.
 
-       Proto2 optional fields do not set this flag, because they already indicate
-       optional with `LABEL_OPTIONAL`. *)
+      Proto2 optional fields do not set this flag, because they already indicate
+      optional with `LABEL_OPTIONAL`. *)
       }
       val make: ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -3636,20 +3680,20 @@ end = struct
         type t =
           | TYPE_DOUBLE
           (**
-             0 is reserved for errors.
-             Order is weird for historical reasons.
+            0 is reserved for errors.
+            Order is weird for historical reasons.
           *)
           | TYPE_FLOAT
           | TYPE_INT64
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+            negative values are likely.
           *)
           | TYPE_UINT64
           | TYPE_INT32
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+            negative values are likely.
           *)
           | TYPE_FIXED64
           | TYPE_FIXED32
@@ -3657,10 +3701,10 @@ end = struct
           | TYPE_STRING
           | TYPE_GROUP
           (**
-             Tag-delimited aggregate.
-             Group type is deprecated and not supported in proto3. However, Proto3
-             implementations should still be able to parse the group wire format and
-             treat group fields as unknown fields.
+            Tag-delimited aggregate.
+            Group type is deprecated and not supported in proto3. However, Proto3
+            implementations should still be able to parse the group wire format and
+            treat group fields as unknown fields.
           *)
           | TYPE_MESSAGE
           (** Length-delimited aggregate. *)
@@ -3690,20 +3734,20 @@ end = struct
         type t =
           | TYPE_DOUBLE
           (**
-             0 is reserved for errors.
-             Order is weird for historical reasons.
+            0 is reserved for errors.
+            Order is weird for historical reasons.
           *)
           | TYPE_FLOAT
           | TYPE_INT64
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+            negative values are likely.
           *)
           | TYPE_UINT64
           | TYPE_INT32
           (**
-             Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-             negative values are likely.
+            Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+            negative values are likely.
           *)
           | TYPE_FIXED64
           | TYPE_FIXED32
@@ -3711,10 +3755,10 @@ end = struct
           | TYPE_STRING
           | TYPE_GROUP
           (**
-             Tag-delimited aggregate.
-             Group type is deprecated and not supported in proto3. However, Proto3
-             implementations should still be able to parse the group wire format and
-             treat group fields as unknown fields.
+            Tag-delimited aggregate.
+            Group type is deprecated and not supported in proto3. However, Proto3
+            implementations should still be able to parse the group wire format and
+            treat group fields as unknown fields.
           *)
           | TYPE_MESSAGE
           (** Length-delimited aggregate. *)
@@ -3862,48 +3906,48 @@ end = struct
       type t = {
       name: string option;
       extendee: string option;(** For extensions, this is the name of the type being extended.  It is
-       resolved in the same manner as type_name. *)
+      resolved in the same manner as type_name. *)
       number: int option;
       label: Label.t option;
       type': Type.t option;(** If type_name is set, this need not be set.  If both this and type_name
-       are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
+      are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP. *)
       type_name: string option;(** For message and enum types, this is the name of the type.  If the name
-       starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-       rules are used to find the type (i.e. first the nested types within this
-       message are searched, then within the parent, on up to the root
-       namespace). *)
+      starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+      rules are used to find the type (i.e. first the nested types within this
+      message are searched, then within the parent, on up to the root
+      namespace). *)
       default_value: string option;(** For numeric types, contains the original text representation of the value.
-       For booleans, "true" or "false".
-       For strings, contains the default text contents (not escaped in any way).
-       For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
+      For booleans, "true" or "false".
+      For strings, contains the default text contents (not escaped in any way).
+      For bytes, contains the C escaped value.  All bytes >= 128 are escaped. *)
       options: FieldOptions.t option;
       oneof_index: int option;(** If set, gives the index of a oneof in the containing type's oneof_decl
-       list.  This field is a member of that oneof. *)
+      list.  This field is a member of that oneof. *)
       json_name: string option;(** JSON name of this field. The value is set by protocol compiler. If the
-       user has set a "json_name" option on this field, that option's value
-       will be used. Otherwise, it's deduced from the field's name by converting
-       it to camelCase. *)
+      user has set a "json_name" option on this field, that option's value
+      will be used. Otherwise, it's deduced from the field's name by converting
+      it to camelCase. *)
       proto3_optional: bool option;(** If true, this is a proto3 "optional". When a proto3 field is optional, it
-       tracks presence regardless of field type.
+      tracks presence regardless of field type.
 
-       When proto3_optional is true, this field must be belong to a oneof to
-       signal to old proto3 clients that presence is tracked for this field. This
-       oneof is known as a "synthetic" oneof, and this field must be its sole
-       member (each proto3 optional field gets its own synthetic oneof). Synthetic
-       oneofs exist in the descriptor only, and do not generate any API. Synthetic
-       oneofs must be ordered after all "real" oneofs.
+      When proto3_optional is true, this field must be belong to a oneof to
+      signal to old proto3 clients that presence is tracked for this field. This
+      oneof is known as a "synthetic" oneof, and this field must be its sole
+      member (each proto3 optional field gets its own synthetic oneof). Synthetic
+      oneofs exist in the descriptor only, and do not generate any API. Synthetic
+      oneofs must be ordered after all "real" oneofs.
 
-       For message fields, proto3_optional doesn't create any semantic change,
-       since non-repeated message fields always track presence. However it still
-       indicates the semantic detail of whether the user wrote "optional" or not.
-       This can be useful for round-tripping the .proto file. For consistency we
-       give message fields a synthetic oneof also, even though it is not required
-       to track presence. This is especially important because the parser can't
-       tell if a field is a message or an enum, so it must always create a
-       synthetic oneof.
+      For message fields, proto3_optional doesn't create any semantic change,
+      since non-repeated message fields always track presence. However it still
+      indicates the semantic detail of whether the user wrote "optional" or not.
+      This can be useful for round-tripping the .proto file. For consistency we
+      give message fields a synthetic oneof also, even though it is not required
+      to track presence. This is especially important because the parser can't
+      tell if a field is a message or an enum, so it must always create a
+      synthetic oneof.
 
-       Proto2 optional fields do not set this flag, because they already indicate
-       optional with `LABEL_OPTIONAL`. *)
+      Proto2 optional fields do not set this flag, because they already indicate
+      optional with `LABEL_OPTIONAL`. *)
       }
       type make_t = ?name:string -> ?extendee:string -> ?number:int -> ?label:Label.t -> ?type':Type.t -> ?type_name:string -> ?default_value:string -> ?options:FieldOptions.t -> ?oneof_index:int -> ?json_name:string -> ?proto3_optional:bool -> unit -> t
       let make ?name ?extendee ?number ?label ?type' ?type_name ?default_value ?options ?oneof_index ?json_name ?proto3_optional () = { name; extendee; number; label; type'; type_name; default_value; options; oneof_index; json_name; proto3_optional }
@@ -4017,12 +4061,12 @@ end = struct
     and EnumDescriptorProto : sig
 
       (**
-         Range of reserved numeric values. Reserved values may not be used by
-         entries in the same enum. Reserved ranges may not overlap.
+        Range of reserved numeric values. Reserved values may not be used by
+        entries in the same enum. Reserved ranges may not overlap.
 
-         Note that this is distinct from DescriptorProto.ReservedRange in that it
-         is inclusive such that it can appropriately represent the entire int32
-         domain.
+        Note that this is distinct from DescriptorProto.ReservedRange in that it
+        is inclusive such that it can appropriately represent the entire int32
+        domain.
       *)
       module rec EnumReservedRange : sig
         type t = {
@@ -4060,10 +4104,10 @@ end = struct
       value: EnumValueDescriptorProto.t list;
       options: EnumOptions.t option;
       reserved_range: EnumReservedRange.t list;(** Range of reserved numeric values. Reserved numeric values may not be used
-       by enum values in the same enum declaration. Reserved ranges may not
-       overlap. *)
+      by enum values in the same enum declaration. Reserved ranges may not
+      overlap. *)
       reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
-       be reserved once. *)
+      be reserved once. *)
       }
       val make: ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       (** Helper function to generate a message using default values *)
@@ -4162,10 +4206,10 @@ end = struct
       value: EnumValueDescriptorProto.t list;
       options: EnumOptions.t option;
       reserved_range: EnumReservedRange.t list;(** Range of reserved numeric values. Reserved numeric values may not be used
-       by enum values in the same enum declaration. Reserved ranges may not
-       overlap. *)
+      by enum values in the same enum declaration. Reserved ranges may not
+      overlap. *)
       reserved_name: string list;(** Reserved enum value names, which may not be reused. A given name may only
-       be reserved once. *)
+      be reserved once. *)
       }
       type make_t = ?name:string -> ?value:EnumValueDescriptorProto.t list -> ?options:EnumOptions.t -> ?reserved_range:EnumReservedRange.t list -> ?reserved_name:string list -> unit -> t
       let make ?name ?(value = []) ?options ?(reserved_range = []) ?(reserved_name = []) () = { name; value; options; reserved_range; reserved_name }
@@ -4340,7 +4384,7 @@ end = struct
       type t = {
       name: string option;
       input_type: string option;(** Input and output type names.  These are resolved in the same way as
-       FieldDescriptorProto.type_name, but must refer to a message type. *)
+      FieldDescriptorProto.type_name, but must refer to a message type. *)
       output_type: string option;
       options: MethodOptions.t option;
       client_streaming: bool;(** Identifies if client streams multiple client messages *)
@@ -4377,7 +4421,7 @@ end = struct
       type t = {
       name: string option;
       input_type: string option;(** Input and output type names.  These are resolved in the same way as
-       FieldDescriptorProto.type_name, but must refer to a message type. *)
+      FieldDescriptorProto.type_name, but must refer to a message type. *)
       output_type: string option;
       options: MethodOptions.t option;
       client_streaming: bool;(** Identifies if client streams multiple client messages *)
@@ -4427,9 +4471,10 @@ end = struct
           (** Generate complete code for parsing, serialization, *)
           | CODE_SIZE
           (**
-             etc.
+            etc.
 
-             Use ReflectionOps to implement these methods.
+
+            Use ReflectionOps to implement these methods.
           *)
           | LITE_RUNTIME
           (** Generate code using MessageLite and the lite runtime. *)
@@ -4447,74 +4492,73 @@ end = struct
       end
       type t = {
       java_package: string option;(** Sets the Java package where classes generated from this .proto will be
-       placed.  By default, the proto package is used, but this is often
-       inappropriate because proto packages do not normally start with backwards
-       domain names. *)
+      placed.  By default, the proto package is used, but this is often
+      inappropriate because proto packages do not normally start with backwards
+      domain names. *)
       java_outer_classname: string option;(** Controls the name of the wrapper Java class generated for the .proto file.
-       That class will always contain the .proto file's getDescriptor() method as
-       well as any top-level extensions defined in the .proto file.
-       If java_multiple_files is disabled, then all the other classes from the
-       .proto file will be nested inside the single wrapper outer class. *)
+      That class will always contain the .proto file's getDescriptor() method as
+      well as any top-level extensions defined in the .proto file.
+      If java_multiple_files is disabled, then all the other classes from the
+      .proto file will be nested inside the single wrapper outer class. *)
       optimize_for: OptimizeMode.t;(** Clients can define custom options in extensions of this message.
-       See the documentation for the "Options" section above. *)
+      See the documentation for the "Options" section above. *)
       java_multiple_files: bool;(** If enabled, then the Java code generator will generate a separate .java
-       file for each top-level message, enum, and service defined in the .proto
-       file.  Thus, these types will *not* be nested inside the wrapper class
-       named by java_outer_classname.  However, the wrapper class will still be
-       generated to contain the file's getDescriptor() method as well as any
-       top-level extensions defined in the file. *)
+      file for each top-level message, enum, and service defined in the .proto
+      file.  Thus, these types will *not* be nested inside the wrapper class
+      named by java_outer_classname.  However, the wrapper class will still be
+      generated to contain the file's getDescriptor() method as well as any
+      top-level extensions defined in the file. *)
       go_package: string option;(** Sets the Go package where structs generated from this .proto will be
-       placed. If omitted, the Go package will be derived from the following:
-         - The basename of the package import path, if provided.
-         - Otherwise, the package statement in the .proto file, if present.
-         - Otherwise, the basename of the .proto file, without extension. *)
+      placed. If omitted, the Go package will be derived from the following:
+      - The basename of the package import path, if provided.
+      - Otherwise, the package statement in the .proto file, if present.
+      - Otherwise, the basename of the .proto file, without extension. *)
       cc_generic_services: bool;(** Should generic services be generated in each language?  "Generic" services
-       are not specific to any particular RPC system.  They are generated by the
-       main code generators in each language (without additional plugins).
-       Generic services were the only kind of service generation supported by
-       early versions of google.protobuf.
+      are not specific to any particular RPC system.  They are generated by the
+      main code generators in each language (without additional plugins).
+      Generic services were the only kind of service generation supported by
+      early versions of google.protobuf.
 
-       Generic services are now considered deprecated in favor of using plugins
-       that generate code specific to your particular RPC system.  Therefore,
-       these default to false.  Old code which depends on generic services should
-       explicitly set them to true. *)
+      Generic services are now considered deprecated in favor of using plugins
+      that generate code specific to your particular RPC system.  Therefore,
+      these default to false.  Old code which depends on generic services should
+      explicitly set them to true. *)
       java_generic_services: bool;
       py_generic_services: bool;
-      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"];(** This option does nothing.
-      @deprecated deprecated in proto file *)
+      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Marked as deprecated in the .proto file"];(** This option does nothing. *)
       deprecated: bool;(** Is this file deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for everything in the file, or it will be completely ignored; in the very
-       least, this is a formalization for deprecating files. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for everything in the file, or it will be completely ignored; in the very
+      least, this is a formalization for deprecating files. *)
       java_string_check_utf8: bool;(** If set true, then the Java2 code generator will generate code that
-       throws an exception whenever an attempt is made to assign a non-UTF-8
-       byte sequence to a string field.
-       Message reflection will do the same.
-       However, an extension field still accepts non-UTF-8 byte sequences.
-       This option has no effect on when used with the lite runtime. *)
+      throws an exception whenever an attempt is made to assign a non-UTF-8
+      byte sequence to a string field.
+      Message reflection will do the same.
+      However, an extension field still accepts non-UTF-8 byte sequences.
+      This option has no effect on when used with the lite runtime. *)
       cc_enable_arenas: bool;(** Enables the use of arenas for the proto messages in this file. This applies
-       only to generated classes for C++. *)
+      only to generated classes for C++. *)
       objc_class_prefix: string option;(** Sets the objective c class prefix which is prepended to all objective c
-       generated classes from this .proto. There is no default. *)
+      generated classes from this .proto. There is no default. *)
       csharp_namespace: string option;(** Namespace for generated classes; defaults to the package. *)
       swift_prefix: string option;(** By default Swift generators will take the proto package and CamelCase it
-       replacing '.' with underscore and use that to prefix the types/symbols
-       defined. When this options is provided, they will use this value instead
-       to prefix the types/symbols defined. *)
+      replacing '.' with underscore and use that to prefix the types/symbols
+      defined. When this options is provided, they will use this value instead
+      to prefix the types/symbols defined. *)
       php_class_prefix: string option;(** Sets the php class prefix which is prepended to all php generated classes
-       from this .proto. Default is empty. *)
+      from this .proto. Default is empty. *)
       php_namespace: string option;(** Use this option to change the namespace of php generated classes. Default
-       is empty. When this option is empty, the package name will be used for
-       determining the namespace. *)
+      is empty. When this option is empty, the package name will be used for
+      determining the namespace. *)
       php_generic_services: bool;
       php_metadata_namespace: string option;(** Use this option to change the namespace of php generated metadata classes.
-       Default is empty. When this option is empty, the proto file name will be
-       used for determining the namespace. *)
+      Default is empty. When this option is empty, the proto file name will be
+      used for determining the namespace. *)
       ruby_package: string option;(** Use this option to change the package of ruby generated classes. Default
-       is empty. When this option is not set, the package name will be used for
-       determining the ruby package. *)
+      is empty. When this option is not set, the package name will be used for
+      determining the ruby package. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here.
-       See the documentation for the "Options" section above. *)
+      See the documentation for the "Options" section above. *)
       extensions': Runtime'.Extensions.t;
       }
       val make: ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
@@ -4550,9 +4594,10 @@ end = struct
           (** Generate complete code for parsing, serialization, *)
           | CODE_SIZE
           (**
-             etc.
+            etc.
 
-             Use ReflectionOps to implement these methods.
+
+            Use ReflectionOps to implement these methods.
           *)
           | LITE_RUNTIME
           (** Generate code using MessageLite and the lite runtime. *)
@@ -4574,9 +4619,10 @@ end = struct
           (** Generate complete code for parsing, serialization, *)
           | CODE_SIZE
           (**
-             etc.
+            etc.
 
-             Use ReflectionOps to implement these methods.
+
+            Use ReflectionOps to implement these methods.
           *)
           | LITE_RUNTIME
           (** Generate code using MessageLite and the lite runtime. *)
@@ -4606,74 +4652,73 @@ end = struct
       let name () = ".google.protobuf.FileOptions"
       type t = {
       java_package: string option;(** Sets the Java package where classes generated from this .proto will be
-       placed.  By default, the proto package is used, but this is often
-       inappropriate because proto packages do not normally start with backwards
-       domain names. *)
+      placed.  By default, the proto package is used, but this is often
+      inappropriate because proto packages do not normally start with backwards
+      domain names. *)
       java_outer_classname: string option;(** Controls the name of the wrapper Java class generated for the .proto file.
-       That class will always contain the .proto file's getDescriptor() method as
-       well as any top-level extensions defined in the .proto file.
-       If java_multiple_files is disabled, then all the other classes from the
-       .proto file will be nested inside the single wrapper outer class. *)
+      That class will always contain the .proto file's getDescriptor() method as
+      well as any top-level extensions defined in the .proto file.
+      If java_multiple_files is disabled, then all the other classes from the
+      .proto file will be nested inside the single wrapper outer class. *)
       optimize_for: OptimizeMode.t;(** Clients can define custom options in extensions of this message.
-       See the documentation for the "Options" section above. *)
+      See the documentation for the "Options" section above. *)
       java_multiple_files: bool;(** If enabled, then the Java code generator will generate a separate .java
-       file for each top-level message, enum, and service defined in the .proto
-       file.  Thus, these types will *not* be nested inside the wrapper class
-       named by java_outer_classname.  However, the wrapper class will still be
-       generated to contain the file's getDescriptor() method as well as any
-       top-level extensions defined in the file. *)
+      file for each top-level message, enum, and service defined in the .proto
+      file.  Thus, these types will *not* be nested inside the wrapper class
+      named by java_outer_classname.  However, the wrapper class will still be
+      generated to contain the file's getDescriptor() method as well as any
+      top-level extensions defined in the file. *)
       go_package: string option;(** Sets the Go package where structs generated from this .proto will be
-       placed. If omitted, the Go package will be derived from the following:
-         - The basename of the package import path, if provided.
-         - Otherwise, the package statement in the .proto file, if present.
-         - Otherwise, the basename of the .proto file, without extension. *)
+      placed. If omitted, the Go package will be derived from the following:
+      - The basename of the package import path, if provided.
+      - Otherwise, the package statement in the .proto file, if present.
+      - Otherwise, the basename of the .proto file, without extension. *)
       cc_generic_services: bool;(** Should generic services be generated in each language?  "Generic" services
-       are not specific to any particular RPC system.  They are generated by the
-       main code generators in each language (without additional plugins).
-       Generic services were the only kind of service generation supported by
-       early versions of google.protobuf.
+      are not specific to any particular RPC system.  They are generated by the
+      main code generators in each language (without additional plugins).
+      Generic services were the only kind of service generation supported by
+      early versions of google.protobuf.
 
-       Generic services are now considered deprecated in favor of using plugins
-       that generate code specific to your particular RPC system.  Therefore,
-       these default to false.  Old code which depends on generic services should
-       explicitly set them to true. *)
+      Generic services are now considered deprecated in favor of using plugins
+      that generate code specific to your particular RPC system.  Therefore,
+      these default to false.  Old code which depends on generic services should
+      explicitly set them to true. *)
       java_generic_services: bool;
       py_generic_services: bool;
-      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Deprecated global"];(** This option does nothing.
-      @deprecated deprecated in proto file *)
+      java_generate_equals_and_hash: bool option[@ocaml.alert protobuf "Marked as deprecated in the .proto file"];(** This option does nothing. *)
       deprecated: bool;(** Is this file deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for everything in the file, or it will be completely ignored; in the very
-       least, this is a formalization for deprecating files. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for everything in the file, or it will be completely ignored; in the very
+      least, this is a formalization for deprecating files. *)
       java_string_check_utf8: bool;(** If set true, then the Java2 code generator will generate code that
-       throws an exception whenever an attempt is made to assign a non-UTF-8
-       byte sequence to a string field.
-       Message reflection will do the same.
-       However, an extension field still accepts non-UTF-8 byte sequences.
-       This option has no effect on when used with the lite runtime. *)
+      throws an exception whenever an attempt is made to assign a non-UTF-8
+      byte sequence to a string field.
+      Message reflection will do the same.
+      However, an extension field still accepts non-UTF-8 byte sequences.
+      This option has no effect on when used with the lite runtime. *)
       cc_enable_arenas: bool;(** Enables the use of arenas for the proto messages in this file. This applies
-       only to generated classes for C++. *)
+      only to generated classes for C++. *)
       objc_class_prefix: string option;(** Sets the objective c class prefix which is prepended to all objective c
-       generated classes from this .proto. There is no default. *)
+      generated classes from this .proto. There is no default. *)
       csharp_namespace: string option;(** Namespace for generated classes; defaults to the package. *)
       swift_prefix: string option;(** By default Swift generators will take the proto package and CamelCase it
-       replacing '.' with underscore and use that to prefix the types/symbols
-       defined. When this options is provided, they will use this value instead
-       to prefix the types/symbols defined. *)
+      replacing '.' with underscore and use that to prefix the types/symbols
+      defined. When this options is provided, they will use this value instead
+      to prefix the types/symbols defined. *)
       php_class_prefix: string option;(** Sets the php class prefix which is prepended to all php generated classes
-       from this .proto. Default is empty. *)
+      from this .proto. Default is empty. *)
       php_namespace: string option;(** Use this option to change the namespace of php generated classes. Default
-       is empty. When this option is empty, the package name will be used for
-       determining the namespace. *)
+      is empty. When this option is empty, the package name will be used for
+      determining the namespace. *)
       php_generic_services: bool;
       php_metadata_namespace: string option;(** Use this option to change the namespace of php generated metadata classes.
-       Default is empty. When this option is empty, the proto file name will be
-       used for determining the namespace. *)
+      Default is empty. When this option is empty, the proto file name will be
+      used for determining the namespace. *)
       ruby_package: string option;(** Use this option to change the package of ruby generated classes. Default
-       is empty. When this option is not set, the package name will be used for
-       determining the ruby package. *)
+      is empty. When this option is not set, the package name will be used for
+      determining the ruby package. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here.
-       See the documentation for the "Options" section above. *)
+      See the documentation for the "Options" section above. *)
       extensions': Runtime'.Extensions.t;
       }
       type make_t = ?java_package:string -> ?java_outer_classname:string -> ?optimize_for:OptimizeMode.t -> ?java_multiple_files:bool -> ?go_package:string -> ?cc_generic_services:bool -> ?java_generic_services:bool -> ?py_generic_services:bool -> ?java_generate_equals_and_hash:bool -> ?deprecated:bool -> ?java_string_check_utf8:bool -> ?cc_enable_arenas:bool -> ?objc_class_prefix:string -> ?csharp_namespace:string -> ?swift_prefix:string -> ?php_class_prefix:string -> ?php_namespace:string -> ?php_generic_services:bool -> ?php_metadata_namespace:string -> ?ruby_package:string -> ?uninterpreted_option:UninterpretedOption.t list -> ?extensions':Runtime'.Extensions.t -> unit -> t
@@ -4745,51 +4790,56 @@ end = struct
     and MessageOptions : sig
       type t = {
       message_set_wire_format: bool;(** Set true to use the old proto1 MessageSet wire format for extensions.
-       This is provided for backwards-compatibility with the MessageSet wire
-       format.  You should not use this for any other reason:  It's less
-       efficient, has fewer features, and is more complicated.
+      This is provided for backwards-compatibility with the MessageSet wire
+      format.  You should not use this for any other reason:  It's less
+      efficient, has fewer features, and is more complicated.
 
-       The message must be defined exactly as follows:
-         message Foo \{
+      The message must be defined exactly as follows:
+      {v
+         message Foo {
            option message_set_wire_format = true;
            extensions 4 to max;
-         \}
-       Note that the message cannot have any defined fields; MessageSets only
-       have extensions.
+         }
+      v}
+      Note that the message cannot have any defined fields; MessageSets only
+      have extensions.
 
-       All extensions of your type must be singular messages; e.g. they cannot
-       be int32s, enums, or repeated messages.
+      All extensions of your type must be singular messages; e.g. they cannot
+      be int32s, enums, or repeated messages.
 
-       Because this is an option, the above two restrictions are not enforced by
-       the protocol compiler. *)
+      Because this is an option, the above two restrictions are not enforced by
+      the protocol compiler. *)
       no_standard_descriptor_accessor: bool;(** Disables the generation of the standard "descriptor()" accessor, which can
-       conflict with a field of the same name.  This is meant to make migration
-       from proto1 easier; new code should avoid fields named "descriptor". *)
+      conflict with a field of the same name.  This is meant to make migration
+      from proto1 easier; new code should avoid fields named "descriptor". *)
       deprecated: bool;(** Is this message deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the message, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating messages. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the message, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating messages. *)
       map_entry: bool option;(** Whether the message is an automatically generated map entry type for the
-       maps field.
+      maps field.
 
-       For maps fields:
+      For maps fields:
+      {v
            map<KeyType, ValueType> map_field = 1;
-       The parsed descriptor looks like:
-           message MapFieldEntry \{
+      v}
+      The parsed descriptor looks like:
+      {v
+           message MapFieldEntry {
                option map_entry = true;
                optional KeyType key = 1;
                optional ValueType value = 2;
-           \}
+           }
            repeated MapFieldEntry map_field = 1;
+      v}
+      Implementations may choose not to generate the map_entry=true message, but
+      use a native map in the target language to hold the keys and values.
+      The reflection APIs in such implementations still need to work as
+      if the field is a repeated message field.
 
-       Implementations may choose not to generate the map_entry=true message, but
-       use a native map in the target language to hold the keys and values.
-       The reflection APIs in such implementations still need to work as
-       if the field is a repeated message field.
-
-       NOTE: Do not set the option in .proto files. Always use the maps syntax
-       instead. The option should only be implicitly set by the proto compiler
-       parser. *)
+      NOTE: Do not set the option in .proto files. Always use the maps syntax
+      instead. The option should only be implicitly set by the proto compiler
+      parser. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -4823,51 +4873,56 @@ end = struct
       let name () = ".google.protobuf.MessageOptions"
       type t = {
       message_set_wire_format: bool;(** Set true to use the old proto1 MessageSet wire format for extensions.
-       This is provided for backwards-compatibility with the MessageSet wire
-       format.  You should not use this for any other reason:  It's less
-       efficient, has fewer features, and is more complicated.
+      This is provided for backwards-compatibility with the MessageSet wire
+      format.  You should not use this for any other reason:  It's less
+      efficient, has fewer features, and is more complicated.
 
-       The message must be defined exactly as follows:
-         message Foo \{
+      The message must be defined exactly as follows:
+      {v
+         message Foo {
            option message_set_wire_format = true;
            extensions 4 to max;
-         \}
-       Note that the message cannot have any defined fields; MessageSets only
-       have extensions.
+         }
+      v}
+      Note that the message cannot have any defined fields; MessageSets only
+      have extensions.
 
-       All extensions of your type must be singular messages; e.g. they cannot
-       be int32s, enums, or repeated messages.
+      All extensions of your type must be singular messages; e.g. they cannot
+      be int32s, enums, or repeated messages.
 
-       Because this is an option, the above two restrictions are not enforced by
-       the protocol compiler. *)
+      Because this is an option, the above two restrictions are not enforced by
+      the protocol compiler. *)
       no_standard_descriptor_accessor: bool;(** Disables the generation of the standard "descriptor()" accessor, which can
-       conflict with a field of the same name.  This is meant to make migration
-       from proto1 easier; new code should avoid fields named "descriptor". *)
+      conflict with a field of the same name.  This is meant to make migration
+      from proto1 easier; new code should avoid fields named "descriptor". *)
       deprecated: bool;(** Is this message deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the message, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating messages. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the message, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating messages. *)
       map_entry: bool option;(** Whether the message is an automatically generated map entry type for the
-       maps field.
+      maps field.
 
-       For maps fields:
+      For maps fields:
+      {v
            map<KeyType, ValueType> map_field = 1;
-       The parsed descriptor looks like:
-           message MapFieldEntry \{
+      v}
+      The parsed descriptor looks like:
+      {v
+           message MapFieldEntry {
                option map_entry = true;
                optional KeyType key = 1;
                optional ValueType value = 2;
-           \}
+           }
            repeated MapFieldEntry map_field = 1;
+      v}
+      Implementations may choose not to generate the map_entry=true message, but
+      use a native map in the target language to hold the keys and values.
+      The reflection APIs in such implementations still need to work as
+      if the field is a repeated message field.
 
-       Implementations may choose not to generate the map_entry=true message, but
-       use a native map in the target language to hold the keys and values.
-       The reflection APIs in such implementations still need to work as
-       if the field is a repeated message field.
-
-       NOTE: Do not set the option in .proto files. Always use the maps syntax
-       instead. The option should only be implicitly set by the proto compiler
-       parser. *)
+      NOTE: Do not set the option in .proto files. Always use the maps syntax
+      instead. The option should only be implicitly set by the proto compiler
+      parser. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -4946,64 +5001,64 @@ end = struct
       end
       type t = {
       ctype: CType.t;(** The ctype option instructs the C++ code generator to use a different
-       representation of the field than it normally would.  See the specific
-       options below.  This option is not yet implemented in the open source
-       release -- sorry, we'll try to include it in a future version! *)
+      representation of the field than it normally would.  See the specific
+      options below.  This option is not yet implemented in the open source
+      release -- sorry, we'll try to include it in a future version! *)
       packed: bool option;(** The packed option can be enabled for repeated primitive fields to enable
-       a more efficient representation on the wire. Rather than repeatedly
-       writing the tag and type for each element, the entire array is encoded as
-       a single length-delimited blob. In proto3, only explicit setting it to
-       false will avoid using packed encoding. *)
+      a more efficient representation on the wire. Rather than repeatedly
+      writing the tag and type for each element, the entire array is encoded as
+      a single length-delimited blob. In proto3, only explicit setting it to
+      false will avoid using packed encoding. *)
       deprecated: bool;(** Clients can define custom options in extensions of this message. See above. *)
       lazy': bool;(** Should this field be parsed lazily?  Lazy applies only to message-type
-       fields.  It means that when the outer message is initially parsed, the
-       inner message's contents will not be parsed but instead stored in encoded
-       form.  The inner message will actually be parsed when it is first accessed.
+      fields.  It means that when the outer message is initially parsed, the
+      inner message's contents will not be parsed but instead stored in encoded
+      form.  The inner message will actually be parsed when it is first accessed.
 
-       This is only a hint.  Implementations are free to choose whether to use
-       eager or lazy parsing regardless of the value of this option.  However,
-       setting this option true suggests that the protocol author believes that
-       using lazy parsing on this field is worth the additional bookkeeping
-       overhead typically needed to implement it.
+      This is only a hint.  Implementations are free to choose whether to use
+      eager or lazy parsing regardless of the value of this option.  However,
+      setting this option true suggests that the protocol author believes that
+      using lazy parsing on this field is worth the additional bookkeeping
+      overhead typically needed to implement it.
 
-       This option does not affect the public interface of any generated code;
-       all method signatures remain the same.  Furthermore, thread-safety of the
-       interface is not affected by this option; const methods remain safe to
-       call from multiple threads concurrently, while non-const methods continue
-       to require exclusive access.
+      This option does not affect the public interface of any generated code;
+      all method signatures remain the same.  Furthermore, thread-safety of the
+      interface is not affected by this option; const methods remain safe to
+      call from multiple threads concurrently, while non-const methods continue
+      to require exclusive access.
 
 
-       Note that implementations may choose not to check required fields within
-       a lazy sub-message.  That is, calling IsInitialized() on the outer message
-       may return true even if the inner message has missing required fields.
-       This is necessary because otherwise the inner message would have to be
-       parsed in order to perform the check, defeating the purpose of lazy
-       parsing.  An implementation which chooses not to check required fields
-       must be consistent about it.  That is, for any particular sub-message, the
-       implementation must either *always* check its required fields, or *never*
-       check its required fields, regardless of whether or not the message has
-       been parsed.
+      Note that implementations may choose not to check required fields within
+      a lazy sub-message.  That is, calling IsInitialized() on the outer message
+      may return true even if the inner message has missing required fields.
+      This is necessary because otherwise the inner message would have to be
+      parsed in order to perform the check, defeating the purpose of lazy
+      parsing.  An implementation which chooses not to check required fields
+      must be consistent about it.  That is, for any particular sub-message, the
+      implementation must either *always* check its required fields, or *never*
+      check its required fields, regardless of whether or not the message has
+      been parsed.
 
-       As of 2021, lazy does no correctness checks on the byte stream during
-       parsing.  This may lead to crashes if and when an invalid byte stream is
-       finally parsed upon access.
+      As of 2021, lazy does no correctness checks on the byte stream during
+      parsing.  This may lead to crashes if and when an invalid byte stream is
+      finally parsed upon access.
 
-       TODO(b/211906113):  Enable validation on lazy fields. *)
+      TODO(b/211906113):  Enable validation on lazy fields. *)
       jstype: JSType.t;(** The jstype option determines the JavaScript type used for values of the
-       field.  The option is permitted only for 64 bit integral and fixed types
-       (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
-       is represented as JavaScript string, which avoids loss of precision that
-       can happen when a large value is converted to a floating point JavaScript.
-       Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
-       use the JavaScript "number" type.  The behavior of the default option
-       JS_NORMAL is implementation dependent.
+      field.  The option is permitted only for 64 bit integral and fixed types
+      (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+      is represented as JavaScript string, which avoids loss of precision that
+      can happen when a large value is converted to a floating point JavaScript.
+      Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+      use the JavaScript "number" type.  The behavior of the default option
+      JS_NORMAL is implementation dependent.
 
-       This option is an enum to permit additional types to be added, e.g.
-       goog.math.Integer. *)
+      This option is an enum to permit additional types to be added, e.g.
+      goog.math.Integer. *)
       weak: bool;(** For Google-internal migration only. Do not use. *)
       unverified_lazy: bool;(** unverified_lazy does no correctness checks on the byte stream. This should
-       only be used where lazy with verification is prohibitive for performance
-       reasons. *)
+      only be used where lazy with verification is prohibitive for performance
+      reasons. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -5135,64 +5190,64 @@ end = struct
       let name () = ".google.protobuf.FieldOptions"
       type t = {
       ctype: CType.t;(** The ctype option instructs the C++ code generator to use a different
-       representation of the field than it normally would.  See the specific
-       options below.  This option is not yet implemented in the open source
-       release -- sorry, we'll try to include it in a future version! *)
+      representation of the field than it normally would.  See the specific
+      options below.  This option is not yet implemented in the open source
+      release -- sorry, we'll try to include it in a future version! *)
       packed: bool option;(** The packed option can be enabled for repeated primitive fields to enable
-       a more efficient representation on the wire. Rather than repeatedly
-       writing the tag and type for each element, the entire array is encoded as
-       a single length-delimited blob. In proto3, only explicit setting it to
-       false will avoid using packed encoding. *)
+      a more efficient representation on the wire. Rather than repeatedly
+      writing the tag and type for each element, the entire array is encoded as
+      a single length-delimited blob. In proto3, only explicit setting it to
+      false will avoid using packed encoding. *)
       deprecated: bool;(** Clients can define custom options in extensions of this message. See above. *)
       lazy': bool;(** Should this field be parsed lazily?  Lazy applies only to message-type
-       fields.  It means that when the outer message is initially parsed, the
-       inner message's contents will not be parsed but instead stored in encoded
-       form.  The inner message will actually be parsed when it is first accessed.
+      fields.  It means that when the outer message is initially parsed, the
+      inner message's contents will not be parsed but instead stored in encoded
+      form.  The inner message will actually be parsed when it is first accessed.
 
-       This is only a hint.  Implementations are free to choose whether to use
-       eager or lazy parsing regardless of the value of this option.  However,
-       setting this option true suggests that the protocol author believes that
-       using lazy parsing on this field is worth the additional bookkeeping
-       overhead typically needed to implement it.
+      This is only a hint.  Implementations are free to choose whether to use
+      eager or lazy parsing regardless of the value of this option.  However,
+      setting this option true suggests that the protocol author believes that
+      using lazy parsing on this field is worth the additional bookkeeping
+      overhead typically needed to implement it.
 
-       This option does not affect the public interface of any generated code;
-       all method signatures remain the same.  Furthermore, thread-safety of the
-       interface is not affected by this option; const methods remain safe to
-       call from multiple threads concurrently, while non-const methods continue
-       to require exclusive access.
+      This option does not affect the public interface of any generated code;
+      all method signatures remain the same.  Furthermore, thread-safety of the
+      interface is not affected by this option; const methods remain safe to
+      call from multiple threads concurrently, while non-const methods continue
+      to require exclusive access.
 
 
-       Note that implementations may choose not to check required fields within
-       a lazy sub-message.  That is, calling IsInitialized() on the outer message
-       may return true even if the inner message has missing required fields.
-       This is necessary because otherwise the inner message would have to be
-       parsed in order to perform the check, defeating the purpose of lazy
-       parsing.  An implementation which chooses not to check required fields
-       must be consistent about it.  That is, for any particular sub-message, the
-       implementation must either *always* check its required fields, or *never*
-       check its required fields, regardless of whether or not the message has
-       been parsed.
+      Note that implementations may choose not to check required fields within
+      a lazy sub-message.  That is, calling IsInitialized() on the outer message
+      may return true even if the inner message has missing required fields.
+      This is necessary because otherwise the inner message would have to be
+      parsed in order to perform the check, defeating the purpose of lazy
+      parsing.  An implementation which chooses not to check required fields
+      must be consistent about it.  That is, for any particular sub-message, the
+      implementation must either *always* check its required fields, or *never*
+      check its required fields, regardless of whether or not the message has
+      been parsed.
 
-       As of 2021, lazy does no correctness checks on the byte stream during
-       parsing.  This may lead to crashes if and when an invalid byte stream is
-       finally parsed upon access.
+      As of 2021, lazy does no correctness checks on the byte stream during
+      parsing.  This may lead to crashes if and when an invalid byte stream is
+      finally parsed upon access.
 
-       TODO(b/211906113):  Enable validation on lazy fields. *)
+      TODO(b/211906113):  Enable validation on lazy fields. *)
       jstype: JSType.t;(** The jstype option determines the JavaScript type used for values of the
-       field.  The option is permitted only for 64 bit integral and fixed types
-       (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
-       is represented as JavaScript string, which avoids loss of precision that
-       can happen when a large value is converted to a floating point JavaScript.
-       Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
-       use the JavaScript "number" type.  The behavior of the default option
-       JS_NORMAL is implementation dependent.
+      field.  The option is permitted only for 64 bit integral and fixed types
+      (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+      is represented as JavaScript string, which avoids loss of precision that
+      can happen when a large value is converted to a floating point JavaScript.
+      Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+      use the JavaScript "number" type.  The behavior of the default option
+      JS_NORMAL is implementation dependent.
 
-       This option is an enum to permit additional types to be added, e.g.
-       goog.math.Integer. *)
+      This option is an enum to permit additional types to be added, e.g.
+      goog.math.Integer. *)
       weak: bool;(** For Google-internal migration only. Do not use. *)
       unverified_lazy: bool;(** unverified_lazy does no correctness checks on the byte stream. This should
-       only be used where lazy with verification is prohibitive for performance
-       reasons. *)
+      only be used where lazy with verification is prohibitive for performance
+      reasons. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -5302,11 +5357,11 @@ end = struct
     and EnumOptions : sig
       type t = {
       allow_alias: bool option;(** Set this option to true to allow mapping different tag names to the same
-       value. *)
+      value. *)
       deprecated: bool;(** Is this enum deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the enum, or it will be completely ignored; in the very least, this
-       is a formalization for deprecating enums. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the enum, or it will be completely ignored; in the very least, this
+      is a formalization for deprecating enums. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -5340,11 +5395,11 @@ end = struct
       let name () = ".google.protobuf.EnumOptions"
       type t = {
       allow_alias: bool option;(** Set this option to true to allow mapping different tag names to the same
-       value. *)
+      value. *)
       deprecated: bool;(** Is this enum deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the enum, or it will be completely ignored; in the very least, this
-       is a formalization for deprecating enums. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the enum, or it will be completely ignored; in the very least, this
+      is a formalization for deprecating enums. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -5381,9 +5436,9 @@ end = struct
     and EnumValueOptions : sig
       type t = {
       deprecated: bool;(** Is this enum value deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the enum value, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating enum values. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the enum value, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating enum values. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -5417,9 +5472,9 @@ end = struct
       let name () = ".google.protobuf.EnumValueOptions"
       type t = {
       deprecated: bool;(** Is this enum value deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the enum value, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating enum values. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the enum value, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating enum values. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -5454,9 +5509,9 @@ end = struct
     and ServiceOptions : sig
       type t = {
       deprecated: bool;(** Is this service deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the service, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating services. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the service, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating services. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -5490,9 +5545,9 @@ end = struct
       let name () = ".google.protobuf.ServiceOptions"
       type t = {
       deprecated: bool;(** Is this service deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the service, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating services. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the service, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating services. *)
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
       }
@@ -5527,9 +5582,9 @@ end = struct
     and MethodOptions : sig
 
       (**
-         Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-         or neither? HTTP based RPC implementation may choose GET verb for safe
-         methods, and PUT verb for idempotent methods instead of the default POST.
+        Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+        or neither? HTTP based RPC implementation may choose GET verb for safe
+        methods, and PUT verb for idempotent methods instead of the default POST.
       *)
       module rec IdempotencyLevel : sig
         type t =
@@ -5552,9 +5607,9 @@ end = struct
       end
       type t = {
       deprecated: bool;(** Is this method deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the method, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating methods. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the method, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating methods. *)
       idempotency_level: IdempotencyLevel.t;
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
@@ -5638,9 +5693,9 @@ end = struct
       let name () = ".google.protobuf.MethodOptions"
       type t = {
       deprecated: bool;(** Is this method deprecated?
-       Depending on the target platform, this can emit Deprecated annotations
-       for the method, or it will be completely ignored; in the very least,
-       this is a formalization for deprecating methods. *)
+      Depending on the target platform, this can emit Deprecated annotations
+      for the method, or it will be completely ignored; in the very least,
+      this is a formalization for deprecating methods. *)
       idempotency_level: IdempotencyLevel.t;
       uninterpreted_option: UninterpretedOption.t list;(** The parser stores options it doesn't recognize here. See above. *)
       extensions': Runtime'.Extensions.t;
@@ -5678,11 +5733,11 @@ end = struct
     and UninterpretedOption : sig
 
       (**
-         The name of the uninterpreted option.  Each string represents a segment in
-         a dot-separated name.  is_extension is true iff a segment represents an
-         extension (denoted with parentheses in options specs in .proto files).
-         E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
-         "foo.(bar.baz).moo".
+        The name of the uninterpreted option.  Each string represents a segment in
+        a dot-separated name.  is_extension is true iff a segment represents an
+        extension (denoted with parentheses in options specs in .proto files).
+        E.g.,\{ \["foo", false\], \["bar.baz", true\], \["moo", false\] \} represents
+        "foo.(bar.baz).moo".
       *)
       module rec NamePart : sig
         type t = {
@@ -5718,7 +5773,7 @@ end = struct
       type t = {
       name: NamePart.t list;
       identifier_value: string option;(** The value of the uninterpreted option, in whatever type the tokenizer
-       identified it as during parsing. Exactly one of these should be set. *)
+      identified it as during parsing. Exactly one of these should be set. *)
       positive_int_value: int option;
       negative_int_value: int option;
       double_value: float option;
@@ -5820,7 +5875,7 @@ end = struct
       type t = {
       name: NamePart.t list;
       identifier_value: string option;(** The value of the uninterpreted option, in whatever type the tokenizer
-       identified it as during parsing. Exactly one of these should be set. *)
+      identified it as during parsing. Exactly one of these should be set. *)
       positive_int_value: int option;
       negative_int_value: int option;
       double_value: float option;
@@ -5868,52 +5923,63 @@ end = struct
       module rec Location : sig
         type t = {
         path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
-         location.
+        location.
 
-         Each element is a field number or an index.  They form a path from
-         the root FileDescriptorProto to the place where the definition occurs.
-         For example, this path:
-           \[ 4, 3, 2, 7, 1 \]
-         refers to:
+        Each element is a field number or an index.  They form a path from
+        the root FileDescriptorProto to the place where the definition occurs.
+        For example, this path:
+        {v
+           [ 4, 3, 2, 7, 1 ]
+        v}
+        refers to:
+        {v
            file.message_type(3)  // 4, 3
                .field(7)         // 2, 7
                .name()           // 1
-         This is because FileDescriptorProto.message_type has field number 4:
+        v}
+        This is because FileDescriptorProto.message_type has field number 4:
+        {v
            repeated DescriptorProto message_type = 4;
-         and DescriptorProto.field has field number 2:
+        v}
+        and DescriptorProto.field has field number 2:
+        {v
            repeated FieldDescriptorProto field = 2;
-         and FieldDescriptorProto.name has field number 1:
+        v}
+        and FieldDescriptorProto.name has field number 1:
+        {v
            optional string name = 1;
-
-         Thus, the above path gives the location of a field name.  If we removed
-         the last element:
-           \[ 4, 3, 2, 7 \]
-         this path refers to the whole field declaration (from the beginning
-         of the label to the terminating semicolon). *)
+        v}
+        Thus, the above path gives the location of a field name.  If we removed
+        the last element:
+        {v
+           [ 4, 3, 2, 7 ]
+        v}
+        this path refers to the whole field declaration (from the beginning
+        of the label to the terminating semicolon). *)
         span: int list;(** Always has exactly three or four elements: start line, start column,
-         end line (optional, otherwise assumed same as start line), end column.
-         These are packed into a single field for efficiency.  Note that line
-         and column numbers are zero-based -- typically you will want to add
-         1 to each before displaying to a user. *)
+        end line (optional, otherwise assumed same as start line), end column.
+        These are packed into a single field for efficiency.  Note that line
+        and column numbers are zero-based -- typically you will want to add
+        1 to each before displaying to a user. *)
         leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
-         comments appearing before and after the declaration which appear to be
-         attached to the declaration.
+        comments appearing before and after the declaration which appear to be
+        attached to the declaration.
 
-         A series of line comments appearing on consecutive lines, with no other
-         tokens appearing on those lines, will be treated as a single comment.
+        A series of line comments appearing on consecutive lines, with no other
+        tokens appearing on those lines, will be treated as a single comment.
 
-         leading_detached_comments will keep paragraphs of comments that appear
-         before (but not connected to) the current element. Each paragraph,
-         separated by empty lines, will be one comment element in the repeated
-         field.
+        leading_detached_comments will keep paragraphs of comments that appear
+        before (but not connected to) the current element. Each paragraph,
+        separated by empty lines, will be one comment element in the repeated
+        field.
 
-         Only the comment content is provided; comment markers (e.g. //) are
-         stripped out.  For block comments, leading whitespace and an asterisk
-         will be stripped from the beginning of each line other than the first.
-         Newlines are included in the output.
+        Only the comment content is provided; comment markers (e.g. //) are
+        stripped out.  For block comments, leading whitespace and an asterisk
+        will be stripped from the beginning of each line other than the first.
+        Newlines are included in the output.
 
-         Examples:
-
+        Examples:
+        {v
            optional int32 foo = 1;  // Comment attached to foo.
            // Comment attached to bar.
            optional int32 bar = 2;
@@ -5941,7 +6007,8 @@ end = struct
             * grault. */
            optional int32 grault = 6;
 
-           // ignored detached comments. *)
+           // ignored detached comments.
+        v} *)
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
@@ -5973,49 +6040,54 @@ end = struct
       end
       type t = (Location.t list)
       (**
-      @param location A Location identifies a piece of source code in a .proto file which
-       corresponds to a particular definition.  This information is intended
-       to be useful to IDEs, code indexers, documentation generators, and similar
-       tools.
+      A Location identifies a piece of source code in a .proto file which
+      corresponds to a particular definition.  This information is intended
+      to be useful to IDEs, code indexers, documentation generators, and similar
+      tools.
 
-       For example, say we have a file like:
-         message Foo \{
+      For example, say we have a file like:
+      {v
+         message Foo {
            optional string foo = 1;
-         \}
-       Let's look at just the field definition:
+         }
+      v}
+      Let's look at just the field definition:
+      {v
          optional string foo = 1;
          ^       ^^     ^^  ^  ^^^
          a       bc     de  f  ghi
-       We have the following locations:
+      v}
+      We have the following locations:
+      {v
          span   path               represents
-         \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
-         \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
-         \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
-         \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
-         \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
-
-       Notes:
-       - A location may refer to a repeated field itself (i.e. not to any
-         particular index within it).  This is used whenever a set of elements are
-         logically enclosed in a single code segment.  For example, an entire
-         extend block (possibly containing multiple extension definitions) will
-         have an outer location whose path refers to the "extensions" repeated
-         field without an index.
-       - Multiple locations may have the same path.  This happens when a single
-         logical declaration is spread out across multiple places.  The most
-         obvious example is the "extend" block again -- there may be multiple
-         extend blocks in the same scope, each of which will have the same path.
-       - A location's span is not always a subset of its parent's span.  For
-         example, the "extendee" of an extension declaration appears at the
-         beginning of the "extend" block and is shared by all extensions within
-         the block.
-       - Just because a location's span is a subset of some other location's span
-         does not mean that it is a descendant.  For example, a "group" defines
-         both a type and a field in a single declaration.  Thus, the locations
-         corresponding to the type and field and their components will overlap.
-       - Code which tries to interpret locations should probably be designed to
-         ignore those that it doesn't understand, as more types of locations could
-         be recorded in the future.
+         [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+         [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+         [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+         [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+         [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+      v}
+      Notes:
+      - A location may refer to a repeated field itself (i.e. not to any
+      particular index within it).  This is used whenever a set of elements are
+      logically enclosed in a single code segment.  For example, an entire
+      extend block (possibly containing multiple extension definitions) will
+      have an outer location whose path refers to the "extensions" repeated
+      field without an index.
+      - Multiple locations may have the same path.  This happens when a single
+      logical declaration is spread out across multiple places.  The most
+      obvious example is the "extend" block again -- there may be multiple
+      extend blocks in the same scope, each of which will have the same path.
+      - A location's span is not always a subset of its parent's span.  For
+      example, the "extendee" of an extension declaration appears at the
+      beginning of the "extend" block and is shared by all extensions within
+      the block.
+      - Just because a location's span is a subset of some other location's span
+      does not mean that it is a descendant.  For example, a "group" defines
+      both a type and a field in a single declaration.  Thus, the locations
+      corresponding to the type and field and their components will overlap.
+      - Code which tries to interpret locations should probably be designed to
+      ignore those that it doesn't understand, as more types of locations could
+      be recorded in the future.
       *)
 
       val make: ?location:Location.t list -> unit -> t
@@ -6048,52 +6120,63 @@ end = struct
       module rec Location : sig
         type t = {
         path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
-         location.
+        location.
 
-         Each element is a field number or an index.  They form a path from
-         the root FileDescriptorProto to the place where the definition occurs.
-         For example, this path:
-           \[ 4, 3, 2, 7, 1 \]
-         refers to:
+        Each element is a field number or an index.  They form a path from
+        the root FileDescriptorProto to the place where the definition occurs.
+        For example, this path:
+        {v
+           [ 4, 3, 2, 7, 1 ]
+        v}
+        refers to:
+        {v
            file.message_type(3)  // 4, 3
                .field(7)         // 2, 7
                .name()           // 1
-         This is because FileDescriptorProto.message_type has field number 4:
+        v}
+        This is because FileDescriptorProto.message_type has field number 4:
+        {v
            repeated DescriptorProto message_type = 4;
-         and DescriptorProto.field has field number 2:
+        v}
+        and DescriptorProto.field has field number 2:
+        {v
            repeated FieldDescriptorProto field = 2;
-         and FieldDescriptorProto.name has field number 1:
+        v}
+        and FieldDescriptorProto.name has field number 1:
+        {v
            optional string name = 1;
-
-         Thus, the above path gives the location of a field name.  If we removed
-         the last element:
-           \[ 4, 3, 2, 7 \]
-         this path refers to the whole field declaration (from the beginning
-         of the label to the terminating semicolon). *)
+        v}
+        Thus, the above path gives the location of a field name.  If we removed
+        the last element:
+        {v
+           [ 4, 3, 2, 7 ]
+        v}
+        this path refers to the whole field declaration (from the beginning
+        of the label to the terminating semicolon). *)
         span: int list;(** Always has exactly three or four elements: start line, start column,
-         end line (optional, otherwise assumed same as start line), end column.
-         These are packed into a single field for efficiency.  Note that line
-         and column numbers are zero-based -- typically you will want to add
-         1 to each before displaying to a user. *)
+        end line (optional, otherwise assumed same as start line), end column.
+        These are packed into a single field for efficiency.  Note that line
+        and column numbers are zero-based -- typically you will want to add
+        1 to each before displaying to a user. *)
         leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
-         comments appearing before and after the declaration which appear to be
-         attached to the declaration.
+        comments appearing before and after the declaration which appear to be
+        attached to the declaration.
 
-         A series of line comments appearing on consecutive lines, with no other
-         tokens appearing on those lines, will be treated as a single comment.
+        A series of line comments appearing on consecutive lines, with no other
+        tokens appearing on those lines, will be treated as a single comment.
 
-         leading_detached_comments will keep paragraphs of comments that appear
-         before (but not connected to) the current element. Each paragraph,
-         separated by empty lines, will be one comment element in the repeated
-         field.
+        leading_detached_comments will keep paragraphs of comments that appear
+        before (but not connected to) the current element. Each paragraph,
+        separated by empty lines, will be one comment element in the repeated
+        field.
 
-         Only the comment content is provided; comment markers (e.g. //) are
-         stripped out.  For block comments, leading whitespace and an asterisk
-         will be stripped from the beginning of each line other than the first.
-         Newlines are included in the output.
+        Only the comment content is provided; comment markers (e.g. //) are
+        stripped out.  For block comments, leading whitespace and an asterisk
+        will be stripped from the beginning of each line other than the first.
+        Newlines are included in the output.
 
-         Examples:
-
+        Examples:
+        {v
            optional int32 foo = 1;  // Comment attached to foo.
            // Comment attached to bar.
            optional int32 bar = 2;
@@ -6121,7 +6204,8 @@ end = struct
             * grault. */
            optional int32 grault = 6;
 
-           // ignored detached comments. *)
+           // ignored detached comments.
+        v} *)
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
@@ -6155,52 +6239,63 @@ end = struct
         let name () = ".google.protobuf.SourceCodeInfo.Location"
         type t = {
         path: int list;(** Identifies which part of the FileDescriptorProto was defined at this
-         location.
+        location.
 
-         Each element is a field number or an index.  They form a path from
-         the root FileDescriptorProto to the place where the definition occurs.
-         For example, this path:
-           \[ 4, 3, 2, 7, 1 \]
-         refers to:
+        Each element is a field number or an index.  They form a path from
+        the root FileDescriptorProto to the place where the definition occurs.
+        For example, this path:
+        {v
+           [ 4, 3, 2, 7, 1 ]
+        v}
+        refers to:
+        {v
            file.message_type(3)  // 4, 3
                .field(7)         // 2, 7
                .name()           // 1
-         This is because FileDescriptorProto.message_type has field number 4:
+        v}
+        This is because FileDescriptorProto.message_type has field number 4:
+        {v
            repeated DescriptorProto message_type = 4;
-         and DescriptorProto.field has field number 2:
+        v}
+        and DescriptorProto.field has field number 2:
+        {v
            repeated FieldDescriptorProto field = 2;
-         and FieldDescriptorProto.name has field number 1:
+        v}
+        and FieldDescriptorProto.name has field number 1:
+        {v
            optional string name = 1;
-
-         Thus, the above path gives the location of a field name.  If we removed
-         the last element:
-           \[ 4, 3, 2, 7 \]
-         this path refers to the whole field declaration (from the beginning
-         of the label to the terminating semicolon). *)
+        v}
+        Thus, the above path gives the location of a field name.  If we removed
+        the last element:
+        {v
+           [ 4, 3, 2, 7 ]
+        v}
+        this path refers to the whole field declaration (from the beginning
+        of the label to the terminating semicolon). *)
         span: int list;(** Always has exactly three or four elements: start line, start column,
-         end line (optional, otherwise assumed same as start line), end column.
-         These are packed into a single field for efficiency.  Note that line
-         and column numbers are zero-based -- typically you will want to add
-         1 to each before displaying to a user. *)
+        end line (optional, otherwise assumed same as start line), end column.
+        These are packed into a single field for efficiency.  Note that line
+        and column numbers are zero-based -- typically you will want to add
+        1 to each before displaying to a user. *)
         leading_comments: string option;(** If this SourceCodeInfo represents a complete declaration, these are any
-         comments appearing before and after the declaration which appear to be
-         attached to the declaration.
+        comments appearing before and after the declaration which appear to be
+        attached to the declaration.
 
-         A series of line comments appearing on consecutive lines, with no other
-         tokens appearing on those lines, will be treated as a single comment.
+        A series of line comments appearing on consecutive lines, with no other
+        tokens appearing on those lines, will be treated as a single comment.
 
-         leading_detached_comments will keep paragraphs of comments that appear
-         before (but not connected to) the current element. Each paragraph,
-         separated by empty lines, will be one comment element in the repeated
-         field.
+        leading_detached_comments will keep paragraphs of comments that appear
+        before (but not connected to) the current element. Each paragraph,
+        separated by empty lines, will be one comment element in the repeated
+        field.
 
-         Only the comment content is provided; comment markers (e.g. //) are
-         stripped out.  For block comments, leading whitespace and an asterisk
-         will be stripped from the beginning of each line other than the first.
-         Newlines are included in the output.
+        Only the comment content is provided; comment markers (e.g. //) are
+        stripped out.  For block comments, leading whitespace and an asterisk
+        will be stripped from the beginning of each line other than the first.
+        Newlines are included in the output.
 
-         Examples:
-
+        Examples:
+        {v
            optional int32 foo = 1;  // Comment attached to foo.
            // Comment attached to bar.
            optional int32 bar = 2;
@@ -6228,7 +6323,8 @@ end = struct
             * grault. */
            optional int32 grault = 6;
 
-           // ignored detached comments. *)
+           // ignored detached comments.
+        v} *)
         trailing_comments: string option;
         leading_detached_comments: string list;
         }
@@ -6268,49 +6364,54 @@ end = struct
       let name () = ".google.protobuf.SourceCodeInfo"
       type t = (Location.t list)
       (**
-      @param location A Location identifies a piece of source code in a .proto file which
-       corresponds to a particular definition.  This information is intended
-       to be useful to IDEs, code indexers, documentation generators, and similar
-       tools.
+      A Location identifies a piece of source code in a .proto file which
+      corresponds to a particular definition.  This information is intended
+      to be useful to IDEs, code indexers, documentation generators, and similar
+      tools.
 
-       For example, say we have a file like:
-         message Foo \{
+      For example, say we have a file like:
+      {v
+         message Foo {
            optional string foo = 1;
-         \}
-       Let's look at just the field definition:
+         }
+      v}
+      Let's look at just the field definition:
+      {v
          optional string foo = 1;
          ^       ^^     ^^  ^  ^^^
          a       bc     de  f  ghi
-       We have the following locations:
+      v}
+      We have the following locations:
+      {v
          span   path               represents
-         \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
-         \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
-         \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
-         \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
-         \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
-
-       Notes:
-       - A location may refer to a repeated field itself (i.e. not to any
-         particular index within it).  This is used whenever a set of elements are
-         logically enclosed in a single code segment.  For example, an entire
-         extend block (possibly containing multiple extension definitions) will
-         have an outer location whose path refers to the "extensions" repeated
-         field without an index.
-       - Multiple locations may have the same path.  This happens when a single
-         logical declaration is spread out across multiple places.  The most
-         obvious example is the "extend" block again -- there may be multiple
-         extend blocks in the same scope, each of which will have the same path.
-       - A location's span is not always a subset of its parent's span.  For
-         example, the "extendee" of an extension declaration appears at the
-         beginning of the "extend" block and is shared by all extensions within
-         the block.
-       - Just because a location's span is a subset of some other location's span
-         does not mean that it is a descendant.  For example, a "group" defines
-         both a type and a field in a single declaration.  Thus, the locations
-         corresponding to the type and field and their components will overlap.
-       - Code which tries to interpret locations should probably be designed to
-         ignore those that it doesn't understand, as more types of locations could
-         be recorded in the future.
+         [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+         [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+         [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+         [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+         [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+      v}
+      Notes:
+      - A location may refer to a repeated field itself (i.e. not to any
+      particular index within it).  This is used whenever a set of elements are
+      logically enclosed in a single code segment.  For example, an entire
+      extend block (possibly containing multiple extension definitions) will
+      have an outer location whose path refers to the "extensions" repeated
+      field without an index.
+      - Multiple locations may have the same path.  This happens when a single
+      logical declaration is spread out across multiple places.  The most
+      obvious example is the "extend" block again -- there may be multiple
+      extend blocks in the same scope, each of which will have the same path.
+      - A location's span is not always a subset of its parent's span.  For
+      example, the "extendee" of an extension declaration appears at the
+      beginning of the "extend" block and is shared by all extensions within
+      the block.
+      - Just because a location's span is a subset of some other location's span
+      does not mean that it is a descendant.  For example, a "group" defines
+      both a type and a field in a single declaration.  Thus, the locations
+      corresponding to the type and field and their components will overlap.
+      - Code which tries to interpret locations should probably be designed to
+      ignore those that it doesn't understand, as more types of locations could
+      be recorded in the future.
       *)
 
       type make_t = ?location:Location.t list -> unit -> t
@@ -6340,13 +6441,13 @@ end = struct
       module rec Annotation : sig
         type t = {
         path: int list;(** Identifies the element in the original source .proto file. This field
-         is formatted the same as SourceCodeInfo.Location.path. *)
+        is formatted the same as SourceCodeInfo.Location.path. *)
         source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
         begin': int option;(** Identifies the starting offset in bytes in the generated code
-         that relates to the identified object. *)
+        that relates to the identified object. *)
         end': int option;(** Identifies the ending offset in bytes in the generated code that
-         relates to the identified offset. The end offset should be one past
-         the last relevant byte (so the length of the text = end - begin). *)
+        relates to the identified offset. The end offset should be one past
+        the last relevant byte (so the length of the text = end - begin). *)
         }
         val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -6376,8 +6477,8 @@ end = struct
       end
       type t = (Annotation.t list)
       (**
-      @param annotation An Annotation connects some span of text in generated code to an element
-       of its generating .proto file.
+      An Annotation connects some span of text in generated code to an element
+      of its generating .proto file.
       *)
 
       val make: ?annotation:Annotation.t list -> unit -> t
@@ -6410,13 +6511,13 @@ end = struct
       module rec Annotation : sig
         type t = {
         path: int list;(** Identifies the element in the original source .proto file. This field
-         is formatted the same as SourceCodeInfo.Location.path. *)
+        is formatted the same as SourceCodeInfo.Location.path. *)
         source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
         begin': int option;(** Identifies the starting offset in bytes in the generated code
-         that relates to the identified object. *)
+        that relates to the identified object. *)
         end': int option;(** Identifies the ending offset in bytes in the generated code that
-         relates to the identified offset. The end offset should be one past
-         the last relevant byte (so the length of the text = end - begin). *)
+        relates to the identified offset. The end offset should be one past
+        the last relevant byte (so the length of the text = end - begin). *)
         }
         val make: ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -6448,13 +6549,13 @@ end = struct
         let name () = ".google.protobuf.GeneratedCodeInfo.Annotation"
         type t = {
         path: int list;(** Identifies the element in the original source .proto file. This field
-         is formatted the same as SourceCodeInfo.Location.path. *)
+        is formatted the same as SourceCodeInfo.Location.path. *)
         source_file: string option;(** Identifies the filesystem path to the original source .proto. *)
         begin': int option;(** Identifies the starting offset in bytes in the generated code
-         that relates to the identified object. *)
+        that relates to the identified object. *)
         end': int option;(** Identifies the ending offset in bytes in the generated code that
-         relates to the identified offset. The end offset should be one past
-         the last relevant byte (so the length of the text = end - begin). *)
+        relates to the identified offset. The end offset should be one past
+        the last relevant byte (so the length of the text = end - begin). *)
         }
         type make_t = ?path:int list -> ?source_file:string -> ?begin':int -> ?end':int -> unit -> t
         let make ?(path = []) ?source_file ?begin' ?end' () = { path; source_file; begin'; end' }
@@ -6490,8 +6591,8 @@ end = struct
       let name () = ".google.protobuf.GeneratedCodeInfo"
       type t = (Annotation.t list)
       (**
-      @param annotation An Annotation connects some span of text in generated code to an element
-       of its generating .proto file.
+      An Annotation connects some span of text in generated code to an element
+      of its generating .proto file.
       *)
 
       type make_t = ?annotation:Annotation.t list -> unit -> t

--- a/src/spec/options.ml
+++ b/src/spec/options.ml
@@ -27,8 +27,7 @@ end
 (**/**)
 module rec Options : sig
   type t = (bool)
-  type make_t = ?mangle_names:bool -> unit -> t
-  val make: make_t
+  val make: ?mangle_names:bool -> unit -> t
   (** Helper function to generate a message using default values *)
 
   val to_proto: t -> Runtime'.Writer.t
@@ -47,6 +46,7 @@ module rec Options : sig
   (** Fully qualified protobuf name of this message *)
 
   (**/**)
+  type make_t = ?mangle_names:bool -> unit -> t
   val merge: t -> t -> t
   val to_proto': Runtime'.Writer.t -> t -> unit
   val from_proto_exn: Runtime'.Reader.t -> t

--- a/src/spec/plugin.ml
+++ b/src/spec/plugin.ml
@@ -28,239 +28,758 @@ end
 module rec Google : sig
   module rec Protobuf : sig
     module rec Compiler : sig
+
+      (** The version number of protocol compiler. *)
       module rec Version : sig
-        val name: unit -> string
-        type t = { major: int option; minor: int option; patch: int option; suffix: string option }
+        type t = {
+        major: int option;
+        minor: int option;
+        patch: int option;
+        suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+         be empty for mainline stable releases. *)
+        }
         type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (** An encoded CodeGeneratorRequest is written to the plugin's stdin. *)
       and CodeGeneratorRequest : sig
-        val name: unit -> string
-        type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
+        type t = {
+        file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
+         code generator should generate code only for these files.  Each file's
+         descriptor will be included in proto_file, below. *)
+        parameter: string option;(** The generator parameter passed on the command-line. *)
+        compiler_version: Version.t option;(** The version number of protocol compiler. *)
+        proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
+         they import.  The files will appear in topological order, so each file
+         appears before any file that imports it.
+
+         protoc guarantees that all proto_files will be written after
+         the fields above, even though this is not technically guaranteed by the
+         protobuf wire format.  This theoretically could allow a plugin to stream
+         in the FileDescriptorProtos and handle them one by one rather than read
+         the entire set into memory at once.  However, as of this writing, this
+         is not similarly optimized on protoc's end -- it will store all fields in
+         memory at once before sending them to the plugin.
+
+         Type names of fields and extensions in the FileDescriptorProto are always
+         fully qualified. *)
+        }
         type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (** The plugin writes an encoded CodeGeneratorResponse to stdout. *)
       and CodeGeneratorResponse : sig
+
+        (** Sync with code_generator.h. *)
         module rec Feature : sig
-          type t = FEATURE_NONE | FEATURE_PROTO3_OPTIONAL
+          type t =
+            | FEATURE_NONE
+            | FEATURE_PROTO3_OPTIONAL
+
           val name: unit -> string
+          (** Fully qualified protobuf name of this enum *)
+
+          (**/**)
           val to_int: t -> int
           val from_int: int -> t Runtime'.Result.t
           val from_int_exn: int -> t
           val to_string: t -> string
           val from_string_exn: string -> t
+          (**/**)
         end
+
+        (** Represents a single generated file. *)
         and File : sig
-          val name: unit -> string
-          type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
+          type t = {
+          name: string option;(** The file name, relative to the output directory.  The name must not
+           contain "." or ".." components and must be relative, not be absolute (so,
+           the file cannot lie outside the output directory).  "/" must be used as
+           the path separator, not "\\".
+
+           If the name is omitted, the content will be appended to the previous
+           file.  This allows the generator to break large files into small chunks,
+           and allows the generated text to be streamed back to protoc so that large
+           files need not reside completely in memory at one time.  Note that as of
+           this writing protoc does not optimize for this -- it will read the entire
+           CodeGeneratorResponse before writing files to disk. *)
+          insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
+           content here is to be inserted into that file at a defined insertion
+           point.  This feature allows a code generator to extend the output
+           produced by another code generator.  The original generator may provide
+           insertion points by placing special annotations in the file that look
+           like:
+             \@\@protoc_insertion_point(NAME)
+           The annotation can have arbitrary text before and after it on the line,
+           which allows it to be placed in a comment.  NAME should be replaced with
+           an identifier naming the point -- this is what other generators will use
+           as the insertion_point.  Code inserted at this point will be placed
+           immediately above the line containing the insertion point (thus multiple
+           insertions to the same point will come out in the order they were added).
+           The double-\@ is intended to make it unlikely that the generated code
+           could contain things that look like insertion points by accident.
+
+           For example, the C++ code generator places the following line in the
+           .pb.h files that it generates:
+             // \@\@protoc_insertion_point(namespace_scope)
+           This line appears within the scope of the file's package namespace, but
+           outside of any particular class.  Another plugin can then specify the
+           insertion_point "namespace_scope" to generate additional classes or
+           other declarations that should be placed in this scope.
+
+           Note that if the line containing the insertion point begins with
+           whitespace, the same whitespace will be added to every line of the
+           inserted text.  This is useful for languages like Python, where
+           indentation matters.  In these languages, the insertion point comment
+           should be indented the same amount as any inserted code will need to be
+           in order to work correctly in that context.
+
+           The code generator that generates the initial file and the one which
+           inserts into it must both run as part of a single invocation of protoc.
+           Code generators are executed in the order in which they appear on the
+           command line.
+
+           If |insertion_point| is present, |name| must also be present. *)
+          content: string option;(** The file contents. *)
+          generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
+           point is used, this information will be appropriately offset and inserted
+           into the code generation metadata for the generated files. *)
+          }
           type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val make: make_t
+          (** Helper function to generate a message using default values *)
+
+          val to_proto: t -> Runtime'.Writer.t
+          (** Serialize the message to binary format *)
+
+          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from binary format *)
+
+          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+          (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+          val name: unit -> string
+          (** Fully qualified protobuf name of this message *)
+
+          (**/**)
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
-          val to_proto: t -> Runtime'.Writer.t
-          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
           val from_proto_exn: Runtime'.Reader.t -> t
-          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
           val from_json_exn: Runtime'.Json.t -> t
-          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (**/**)
         end
-        val name: unit -> string
-        type t = { error: string option; supported_features: int option; file: File.t list }
+        type t = {
+        error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
+         should exit with status code zero even if it reports an error in this way.
+
+         This should be used to indicate errors in .proto files which prevent the
+         code generator from generating correct code.  Errors which indicate a
+         problem in protoc itself -- such as the input CodeGeneratorRequest being
+         unparseable -- should be reported by writing a message to stderr and
+         exiting with a non-zero status code. *)
+        supported_features: int option;(** A bitmask of supported features that the code generator supports.
+         This is a bitwise "or" of values from the Feature enum. *)
+        file: File.t list;
+        }
         type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
     end
   end
 end = struct
   module rec Protobuf : sig
     module rec Compiler : sig
+
+      (** The version number of protocol compiler. *)
       module rec Version : sig
-        val name: unit -> string
-        type t = { major: int option; minor: int option; patch: int option; suffix: string option }
+        type t = {
+        major: int option;
+        minor: int option;
+        patch: int option;
+        suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+         be empty for mainline stable releases. *)
+        }
         type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (** An encoded CodeGeneratorRequest is written to the plugin's stdin. *)
       and CodeGeneratorRequest : sig
-        val name: unit -> string
-        type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
+        type t = {
+        file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
+         code generator should generate code only for these files.  Each file's
+         descriptor will be included in proto_file, below. *)
+        parameter: string option;(** The generator parameter passed on the command-line. *)
+        compiler_version: Version.t option;(** The version number of protocol compiler. *)
+        proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
+         they import.  The files will appear in topological order, so each file
+         appears before any file that imports it.
+
+         protoc guarantees that all proto_files will be written after
+         the fields above, even though this is not technically guaranteed by the
+         protobuf wire format.  This theoretically could allow a plugin to stream
+         in the FileDescriptorProtos and handle them one by one rather than read
+         the entire set into memory at once.  However, as of this writing, this
+         is not similarly optimized on protoc's end -- it will store all fields in
+         memory at once before sending them to the plugin.
+
+         Type names of fields and extensions in the FileDescriptorProto are always
+         fully qualified. *)
+        }
         type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (** The plugin writes an encoded CodeGeneratorResponse to stdout. *)
       and CodeGeneratorResponse : sig
+
+        (** Sync with code_generator.h. *)
         module rec Feature : sig
-          type t = FEATURE_NONE | FEATURE_PROTO3_OPTIONAL
+          type t =
+            | FEATURE_NONE
+            | FEATURE_PROTO3_OPTIONAL
+
           val name: unit -> string
+          (** Fully qualified protobuf name of this enum *)
+
+          (**/**)
           val to_int: t -> int
           val from_int: int -> t Runtime'.Result.t
           val from_int_exn: int -> t
           val to_string: t -> string
           val from_string_exn: string -> t
+          (**/**)
         end
+
+        (** Represents a single generated file. *)
         and File : sig
-          val name: unit -> string
-          type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
+          type t = {
+          name: string option;(** The file name, relative to the output directory.  The name must not
+           contain "." or ".." components and must be relative, not be absolute (so,
+           the file cannot lie outside the output directory).  "/" must be used as
+           the path separator, not "\\".
+
+           If the name is omitted, the content will be appended to the previous
+           file.  This allows the generator to break large files into small chunks,
+           and allows the generated text to be streamed back to protoc so that large
+           files need not reside completely in memory at one time.  Note that as of
+           this writing protoc does not optimize for this -- it will read the entire
+           CodeGeneratorResponse before writing files to disk. *)
+          insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
+           content here is to be inserted into that file at a defined insertion
+           point.  This feature allows a code generator to extend the output
+           produced by another code generator.  The original generator may provide
+           insertion points by placing special annotations in the file that look
+           like:
+             \@\@protoc_insertion_point(NAME)
+           The annotation can have arbitrary text before and after it on the line,
+           which allows it to be placed in a comment.  NAME should be replaced with
+           an identifier naming the point -- this is what other generators will use
+           as the insertion_point.  Code inserted at this point will be placed
+           immediately above the line containing the insertion point (thus multiple
+           insertions to the same point will come out in the order they were added).
+           The double-\@ is intended to make it unlikely that the generated code
+           could contain things that look like insertion points by accident.
+
+           For example, the C++ code generator places the following line in the
+           .pb.h files that it generates:
+             // \@\@protoc_insertion_point(namespace_scope)
+           This line appears within the scope of the file's package namespace, but
+           outside of any particular class.  Another plugin can then specify the
+           insertion_point "namespace_scope" to generate additional classes or
+           other declarations that should be placed in this scope.
+
+           Note that if the line containing the insertion point begins with
+           whitespace, the same whitespace will be added to every line of the
+           inserted text.  This is useful for languages like Python, where
+           indentation matters.  In these languages, the insertion point comment
+           should be indented the same amount as any inserted code will need to be
+           in order to work correctly in that context.
+
+           The code generator that generates the initial file and the one which
+           inserts into it must both run as part of a single invocation of protoc.
+           Code generators are executed in the order in which they appear on the
+           command line.
+
+           If |insertion_point| is present, |name| must also be present. *)
+          content: string option;(** The file contents. *)
+          generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
+           point is used, this information will be appropriately offset and inserted
+           into the code generation metadata for the generated files. *)
+          }
           type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val make: make_t
+          (** Helper function to generate a message using default values *)
+
+          val to_proto: t -> Runtime'.Writer.t
+          (** Serialize the message to binary format *)
+
+          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from binary format *)
+
+          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+          (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+          val name: unit -> string
+          (** Fully qualified protobuf name of this message *)
+
+          (**/**)
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
-          val to_proto: t -> Runtime'.Writer.t
-          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
           val from_proto_exn: Runtime'.Reader.t -> t
-          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
           val from_json_exn: Runtime'.Json.t -> t
-          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (**/**)
         end
-        val name: unit -> string
-        type t = { error: string option; supported_features: int option; file: File.t list }
+        type t = {
+        error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
+         should exit with status code zero even if it reports an error in this way.
+
+         This should be used to indicate errors in .proto files which prevent the
+         code generator from generating correct code.  Errors which indicate a
+         problem in protoc itself -- such as the input CodeGeneratorRequest being
+         unparseable -- should be reported by writing a message to stderr and
+         exiting with a non-zero status code. *)
+        supported_features: int option;(** A bitmask of supported features that the code generator supports.
+         This is a bitwise "or" of values from the Feature enum. *)
+        file: File.t list;
+        }
         type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
     end
   end = struct
     module rec Compiler : sig
+
+      (** The version number of protocol compiler. *)
       module rec Version : sig
-        val name: unit -> string
-        type t = { major: int option; minor: int option; patch: int option; suffix: string option }
+        type t = {
+        major: int option;
+        minor: int option;
+        patch: int option;
+        suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+         be empty for mainline stable releases. *)
+        }
         type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (** An encoded CodeGeneratorRequest is written to the plugin's stdin. *)
       and CodeGeneratorRequest : sig
-        val name: unit -> string
-        type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
+        type t = {
+        file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
+         code generator should generate code only for these files.  Each file's
+         descriptor will be included in proto_file, below. *)
+        parameter: string option;(** The generator parameter passed on the command-line. *)
+        compiler_version: Version.t option;(** The version number of protocol compiler. *)
+        proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
+         they import.  The files will appear in topological order, so each file
+         appears before any file that imports it.
+
+         protoc guarantees that all proto_files will be written after
+         the fields above, even though this is not technically guaranteed by the
+         protobuf wire format.  This theoretically could allow a plugin to stream
+         in the FileDescriptorProtos and handle them one by one rather than read
+         the entire set into memory at once.  However, as of this writing, this
+         is not similarly optimized on protoc's end -- it will store all fields in
+         memory at once before sending them to the plugin.
+
+         Type names of fields and extensions in the FileDescriptorProto are always
+         fully qualified. *)
+        }
         type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
+
+      (** The plugin writes an encoded CodeGeneratorResponse to stdout. *)
       and CodeGeneratorResponse : sig
+
+        (** Sync with code_generator.h. *)
         module rec Feature : sig
-          type t = FEATURE_NONE | FEATURE_PROTO3_OPTIONAL
+          type t =
+            | FEATURE_NONE
+            | FEATURE_PROTO3_OPTIONAL
+
           val name: unit -> string
+          (** Fully qualified protobuf name of this enum *)
+
+          (**/**)
           val to_int: t -> int
           val from_int: int -> t Runtime'.Result.t
           val from_int_exn: int -> t
           val to_string: t -> string
           val from_string_exn: string -> t
+          (**/**)
         end
+
+        (** Represents a single generated file. *)
         and File : sig
-          val name: unit -> string
-          type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
+          type t = {
+          name: string option;(** The file name, relative to the output directory.  The name must not
+           contain "." or ".." components and must be relative, not be absolute (so,
+           the file cannot lie outside the output directory).  "/" must be used as
+           the path separator, not "\\".
+
+           If the name is omitted, the content will be appended to the previous
+           file.  This allows the generator to break large files into small chunks,
+           and allows the generated text to be streamed back to protoc so that large
+           files need not reside completely in memory at one time.  Note that as of
+           this writing protoc does not optimize for this -- it will read the entire
+           CodeGeneratorResponse before writing files to disk. *)
+          insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
+           content here is to be inserted into that file at a defined insertion
+           point.  This feature allows a code generator to extend the output
+           produced by another code generator.  The original generator may provide
+           insertion points by placing special annotations in the file that look
+           like:
+             \@\@protoc_insertion_point(NAME)
+           The annotation can have arbitrary text before and after it on the line,
+           which allows it to be placed in a comment.  NAME should be replaced with
+           an identifier naming the point -- this is what other generators will use
+           as the insertion_point.  Code inserted at this point will be placed
+           immediately above the line containing the insertion point (thus multiple
+           insertions to the same point will come out in the order they were added).
+           The double-\@ is intended to make it unlikely that the generated code
+           could contain things that look like insertion points by accident.
+
+           For example, the C++ code generator places the following line in the
+           .pb.h files that it generates:
+             // \@\@protoc_insertion_point(namespace_scope)
+           This line appears within the scope of the file's package namespace, but
+           outside of any particular class.  Another plugin can then specify the
+           insertion_point "namespace_scope" to generate additional classes or
+           other declarations that should be placed in this scope.
+
+           Note that if the line containing the insertion point begins with
+           whitespace, the same whitespace will be added to every line of the
+           inserted text.  This is useful for languages like Python, where
+           indentation matters.  In these languages, the insertion point comment
+           should be indented the same amount as any inserted code will need to be
+           in order to work correctly in that context.
+
+           The code generator that generates the initial file and the one which
+           inserts into it must both run as part of a single invocation of protoc.
+           Code generators are executed in the order in which they appear on the
+           command line.
+
+           If |insertion_point| is present, |name| must also be present. *)
+          content: string option;(** The file contents. *)
+          generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
+           point is used, this information will be appropriately offset and inserted
+           into the code generation metadata for the generated files. *)
+          }
           type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val make: make_t
+          (** Helper function to generate a message using default values *)
+
+          val to_proto: t -> Runtime'.Writer.t
+          (** Serialize the message to binary format *)
+
+          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from binary format *)
+
+          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+          (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+          val name: unit -> string
+          (** Fully qualified protobuf name of this message *)
+
+          (**/**)
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
-          val to_proto: t -> Runtime'.Writer.t
-          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
           val from_proto_exn: Runtime'.Reader.t -> t
-          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
           val from_json_exn: Runtime'.Json.t -> t
-          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (**/**)
         end
-        val name: unit -> string
-        type t = { error: string option; supported_features: int option; file: File.t list }
+        type t = {
+        error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
+         should exit with status code zero even if it reports an error in this way.
+
+         This should be used to indicate errors in .proto files which prevent the
+         code generator from generating correct code.  Errors which indicate a
+         problem in protoc itself -- such as the input CodeGeneratorRequest being
+         unparseable -- should be reported by writing a message to stderr and
+         exiting with a non-zero status code. *)
+        supported_features: int option;(** A bitmask of supported features that the code generator supports.
+         This is a bitwise "or" of values from the Feature enum. *)
+        file: File.t list;
+        }
         type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end
     end = struct
       module rec Version : sig
-        val name: unit -> string
-        type t = { major: int option; minor: int option; patch: int option; suffix: string option }
+        type t = {
+        major: int option;
+        minor: int option;
+        patch: int option;
+        suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+         be empty for mainline stable releases. *)
+        }
         type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = Version
         let name () = ".google.protobuf.compiler.Version"
-        type t = { major: int option; minor: int option; patch: int option; suffix: string option }
+        type t = {
+        major: int option;
+        minor: int option;
+        patch: int option;
+        suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+         be empty for mainline stable releases. *)
+        }
         type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         let make ?major ?minor ?patch ?suffix () = { major; minor; patch; suffix }
         let merge =
-          let merge_major = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "major", "major"), int32_int) ) in
-          let merge_minor = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "minor", "minor"), int32_int) ) in
-          let merge_patch = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "patch", "patch"), int32_int) ) in
-          let merge_suffix = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "suffix", "suffix"), string) ) in
-          fun t1 t2 -> {
-            major = (merge_major t1.major t2.major);
-            minor = (merge_minor t1.minor t2.minor);
-            patch = (merge_patch t1.patch t2.patch);
-            suffix = (merge_suffix t1.suffix t2.suffix);
-           }
+        let merge_major = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "major", "major"), int32_int) ) in
+        let merge_minor = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "minor", "minor"), int32_int) ) in
+        let merge_patch = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "patch", "patch"), int32_int) ) in
+        let merge_suffix = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((4, "suffix", "suffix"), string) ) in
+        fun t1 t2 -> {
+        major = (merge_major t1.major t2.major);
+        minor = (merge_minor t1.minor t2.minor);
+        patch = (merge_patch t1.patch t2.patch);
+        suffix = (merge_suffix t1.suffix t2.suffix);
+         }
         let spec () = Runtime'.Spec.( basic_opt ((1, "major", "major"), int32_int) ^:: basic_opt ((2, "minor", "minor"), int32_int) ^:: basic_opt ((3, "patch", "patch"), int32_int) ^:: basic_opt ((4, "suffix", "suffix"), string) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -280,34 +799,89 @@ end = struct
         let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
       end
       and CodeGeneratorRequest : sig
-        val name: unit -> string
-        type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
+        type t = {
+        file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
+         code generator should generate code only for these files.  Each file's
+         descriptor will be included in proto_file, below. *)
+        parameter: string option;(** The generator parameter passed on the command-line. *)
+        compiler_version: Version.t option;(** The version number of protocol compiler. *)
+        proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
+         they import.  The files will appear in topological order, so each file
+         appears before any file that imports it.
+
+         protoc guarantees that all proto_files will be written after
+         the fields above, even though this is not technically guaranteed by the
+         protobuf wire format.  This theoretically could allow a plugin to stream
+         in the FileDescriptorProtos and handle them one by one rather than read
+         the entire set into memory at once.  However, as of this writing, this
+         is not similarly optimized on protoc's end -- it will store all fields in
+         memory at once before sending them to the plugin.
+
+         Type names of fields and extensions in the FileDescriptorProto are always
+         fully qualified. *)
+        }
         type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = CodeGeneratorRequest
         let name () = ".google.protobuf.compiler.CodeGeneratorRequest"
-        type t = { file_to_generate: string list; parameter: string option; compiler_version: Version.t option; proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list }
+        type t = {
+        file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
+         code generator should generate code only for these files.  Each file's
+         descriptor will be included in proto_file, below. *)
+        parameter: string option;(** The generator parameter passed on the command-line. *)
+        compiler_version: Version.t option;(** The version number of protocol compiler. *)
+        proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
+         they import.  The files will appear in topological order, so each file
+         appears before any file that imports it.
+
+         protoc guarantees that all proto_files will be written after
+         the fields above, even though this is not technically guaranteed by the
+         protobuf wire format.  This theoretically could allow a plugin to stream
+         in the FileDescriptorProtos and handle them one by one rather than read
+         the entire set into memory at once.  However, as of this writing, this
+         is not similarly optimized on protoc's end -- it will store all fields in
+         memory at once before sending them to the plugin.
+
+         Type names of fields and extensions in the FileDescriptorProto are always
+         fully qualified. *)
+        }
         type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         let make ?(file_to_generate = []) ?parameter ?compiler_version ?(proto_file = []) () = { file_to_generate; parameter; compiler_version; proto_file }
         let merge =
-          let merge_file_to_generate = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "file_to_generate", "fileToGenerate"), string, not_packed) ) in
-          let merge_parameter = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "parameter", "parameter"), string) ) in
-          let merge_compiler_version = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "compiler_version", "compilerVersion"), (message (module Version))) ) in
-          let merge_proto_file = Runtime'.Merge.merge Runtime'.Spec.( repeated ((15, "proto_file", "protoFile"), (message (module Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto)), not_packed) ) in
-          fun t1 t2 -> {
-            file_to_generate = (merge_file_to_generate t1.file_to_generate t2.file_to_generate);
-            parameter = (merge_parameter t1.parameter t2.parameter);
-            compiler_version = (merge_compiler_version t1.compiler_version t2.compiler_version);
-            proto_file = (merge_proto_file t1.proto_file t2.proto_file);
-           }
+        let merge_file_to_generate = Runtime'.Merge.merge Runtime'.Spec.( repeated ((1, "file_to_generate", "fileToGenerate"), string, not_packed) ) in
+        let merge_parameter = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "parameter", "parameter"), string) ) in
+        let merge_compiler_version = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((3, "compiler_version", "compilerVersion"), (message (module Version))) ) in
+        let merge_proto_file = Runtime'.Merge.merge Runtime'.Spec.( repeated ((15, "proto_file", "protoFile"), (message (module Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto)), not_packed) ) in
+        fun t1 t2 -> {
+        file_to_generate = (merge_file_to_generate t1.file_to_generate t2.file_to_generate);
+        parameter = (merge_parameter t1.parameter t2.parameter);
+        compiler_version = (merge_compiler_version t1.compiler_version t2.compiler_version);
+        proto_file = (merge_proto_file t1.proto_file t2.proto_file);
+         }
         let spec () = Runtime'.Spec.( repeated ((1, "file_to_generate", "fileToGenerate"), string, not_packed) ^:: basic_opt ((2, "parameter", "parameter"), string) ^:: basic_opt ((3, "compiler_version", "compilerVersion"), (message (module Version))) ^:: repeated ((15, "proto_file", "protoFile"), (message (module Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto)), not_packed) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -327,52 +901,168 @@ end = struct
         let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
       end
       and CodeGeneratorResponse : sig
+
+        (** Sync with code_generator.h. *)
         module rec Feature : sig
-          type t = FEATURE_NONE | FEATURE_PROTO3_OPTIONAL
+          type t =
+            | FEATURE_NONE
+            | FEATURE_PROTO3_OPTIONAL
+
           val name: unit -> string
+          (** Fully qualified protobuf name of this enum *)
+
+          (**/**)
           val to_int: t -> int
           val from_int: int -> t Runtime'.Result.t
           val from_int_exn: int -> t
           val to_string: t -> string
           val from_string_exn: string -> t
+          (**/**)
         end
+
+        (** Represents a single generated file. *)
         and File : sig
-          val name: unit -> string
-          type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
+          type t = {
+          name: string option;(** The file name, relative to the output directory.  The name must not
+           contain "." or ".." components and must be relative, not be absolute (so,
+           the file cannot lie outside the output directory).  "/" must be used as
+           the path separator, not "\\".
+
+           If the name is omitted, the content will be appended to the previous
+           file.  This allows the generator to break large files into small chunks,
+           and allows the generated text to be streamed back to protoc so that large
+           files need not reside completely in memory at one time.  Note that as of
+           this writing protoc does not optimize for this -- it will read the entire
+           CodeGeneratorResponse before writing files to disk. *)
+          insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
+           content here is to be inserted into that file at a defined insertion
+           point.  This feature allows a code generator to extend the output
+           produced by another code generator.  The original generator may provide
+           insertion points by placing special annotations in the file that look
+           like:
+             \@\@protoc_insertion_point(NAME)
+           The annotation can have arbitrary text before and after it on the line,
+           which allows it to be placed in a comment.  NAME should be replaced with
+           an identifier naming the point -- this is what other generators will use
+           as the insertion_point.  Code inserted at this point will be placed
+           immediately above the line containing the insertion point (thus multiple
+           insertions to the same point will come out in the order they were added).
+           The double-\@ is intended to make it unlikely that the generated code
+           could contain things that look like insertion points by accident.
+
+           For example, the C++ code generator places the following line in the
+           .pb.h files that it generates:
+             // \@\@protoc_insertion_point(namespace_scope)
+           This line appears within the scope of the file's package namespace, but
+           outside of any particular class.  Another plugin can then specify the
+           insertion_point "namespace_scope" to generate additional classes or
+           other declarations that should be placed in this scope.
+
+           Note that if the line containing the insertion point begins with
+           whitespace, the same whitespace will be added to every line of the
+           inserted text.  This is useful for languages like Python, where
+           indentation matters.  In these languages, the insertion point comment
+           should be indented the same amount as any inserted code will need to be
+           in order to work correctly in that context.
+
+           The code generator that generates the initial file and the one which
+           inserts into it must both run as part of a single invocation of protoc.
+           Code generators are executed in the order in which they appear on the
+           command line.
+
+           If |insertion_point| is present, |name| must also be present. *)
+          content: string option;(** The file contents. *)
+          generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
+           point is used, this information will be appropriately offset and inserted
+           into the code generation metadata for the generated files. *)
+          }
           type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val make: make_t
+          (** Helper function to generate a message using default values *)
+
+          val to_proto: t -> Runtime'.Writer.t
+          (** Serialize the message to binary format *)
+
+          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from binary format *)
+
+          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+          (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+          val name: unit -> string
+          (** Fully qualified protobuf name of this message *)
+
+          (**/**)
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
-          val to_proto: t -> Runtime'.Writer.t
-          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
           val from_proto_exn: Runtime'.Reader.t -> t
-          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
           val from_json_exn: Runtime'.Json.t -> t
-          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (**/**)
         end
-        val name: unit -> string
-        type t = { error: string option; supported_features: int option; file: File.t list }
+        type t = {
+        error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
+         should exit with status code zero even if it reports an error in this way.
+
+         This should be used to indicate errors in .proto files which prevent the
+         code generator from generating correct code.  Errors which indicate a
+         problem in protoc itself -- such as the input CodeGeneratorRequest being
+         unparseable -- should be reported by writing a message to stderr and
+         exiting with a non-zero status code. *)
+        supported_features: int option;(** A bitmask of supported features that the code generator supports.
+         This is a bitwise "or" of values from the Feature enum. *)
+        file: File.t list;
+        }
         type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val make: make_t
+        (** Helper function to generate a message using default values *)
+
+        val to_proto: t -> Runtime'.Writer.t
+        (** Serialize the message to binary format *)
+
+        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from binary format *)
+
+        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+        (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+        val name: unit -> string
+        (** Fully qualified protobuf name of this message *)
+
+        (**/**)
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
-        val to_proto: t -> Runtime'.Writer.t
-        val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
         val from_proto_exn: Runtime'.Reader.t -> t
-        val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
         val from_json_exn: Runtime'.Json.t -> t
-        val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+        (**/**)
       end = struct
+        module This'_ = CodeGeneratorResponse
         module rec Feature : sig
-          type t = FEATURE_NONE | FEATURE_PROTO3_OPTIONAL
+          type t =
+            | FEATURE_NONE
+            | FEATURE_PROTO3_OPTIONAL
+
           val name: unit -> string
+          (** Fully qualified protobuf name of this enum *)
+
+          (**/**)
           val to_int: t -> int
           val from_int: int -> t Runtime'.Result.t
           val from_int_exn: int -> t
           val to_string: t -> string
           val from_string_exn: string -> t
+          (**/**)
         end = struct
-          type t = FEATURE_NONE | FEATURE_PROTO3_OPTIONAL
+          module This'_ = Feature
+          type t =
+            | FEATURE_NONE
+            | FEATURE_PROTO3_OPTIONAL
+
           let name () = ".google.protobuf.compiler.CodeGeneratorResponse.Feature"
           let to_int = function
             | FEATURE_NONE -> 0
@@ -392,34 +1082,155 @@ end = struct
 
         end
         and File : sig
-          val name: unit -> string
-          type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
+          type t = {
+          name: string option;(** The file name, relative to the output directory.  The name must not
+           contain "." or ".." components and must be relative, not be absolute (so,
+           the file cannot lie outside the output directory).  "/" must be used as
+           the path separator, not "\\".
+
+           If the name is omitted, the content will be appended to the previous
+           file.  This allows the generator to break large files into small chunks,
+           and allows the generated text to be streamed back to protoc so that large
+           files need not reside completely in memory at one time.  Note that as of
+           this writing protoc does not optimize for this -- it will read the entire
+           CodeGeneratorResponse before writing files to disk. *)
+          insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
+           content here is to be inserted into that file at a defined insertion
+           point.  This feature allows a code generator to extend the output
+           produced by another code generator.  The original generator may provide
+           insertion points by placing special annotations in the file that look
+           like:
+             \@\@protoc_insertion_point(NAME)
+           The annotation can have arbitrary text before and after it on the line,
+           which allows it to be placed in a comment.  NAME should be replaced with
+           an identifier naming the point -- this is what other generators will use
+           as the insertion_point.  Code inserted at this point will be placed
+           immediately above the line containing the insertion point (thus multiple
+           insertions to the same point will come out in the order they were added).
+           The double-\@ is intended to make it unlikely that the generated code
+           could contain things that look like insertion points by accident.
+
+           For example, the C++ code generator places the following line in the
+           .pb.h files that it generates:
+             // \@\@protoc_insertion_point(namespace_scope)
+           This line appears within the scope of the file's package namespace, but
+           outside of any particular class.  Another plugin can then specify the
+           insertion_point "namespace_scope" to generate additional classes or
+           other declarations that should be placed in this scope.
+
+           Note that if the line containing the insertion point begins with
+           whitespace, the same whitespace will be added to every line of the
+           inserted text.  This is useful for languages like Python, where
+           indentation matters.  In these languages, the insertion point comment
+           should be indented the same amount as any inserted code will need to be
+           in order to work correctly in that context.
+
+           The code generator that generates the initial file and the one which
+           inserts into it must both run as part of a single invocation of protoc.
+           Code generators are executed in the order in which they appear on the
+           command line.
+
+           If |insertion_point| is present, |name| must also be present. *)
+          content: string option;(** The file contents. *)
+          generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
+           point is used, this information will be appropriately offset and inserted
+           into the code generation metadata for the generated files. *)
+          }
           type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val make: make_t
+          (** Helper function to generate a message using default values *)
+
+          val to_proto: t -> Runtime'.Writer.t
+          (** Serialize the message to binary format *)
+
+          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from binary format *)
+
+          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
+          (** Serialize to Json (compatible with Yojson.Basic.t) *)
+
+          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (** Deserialize from Json (compatible with Yojson.Basic.t) *)
+
+          val name: unit -> string
+          (** Fully qualified protobuf name of this message *)
+
+          (**/**)
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
-          val to_proto: t -> Runtime'.Writer.t
-          val from_proto: Runtime'.Reader.t -> (t, [> Runtime'.Result.error]) result
           val from_proto_exn: Runtime'.Reader.t -> t
-          val to_json: Runtime'.Json_options.t -> t -> Runtime'.Json.t
           val from_json_exn: Runtime'.Json.t -> t
-          val from_json: Runtime'.Json.t -> (t, [> Runtime'.Result.error]) result
+          (**/**)
         end = struct
+          module This'_ = File
           let name () = ".google.protobuf.compiler.CodeGeneratorResponse.File"
-          type t = { name: string option; insertion_point: string option; content: string option; generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option }
+          type t = {
+          name: string option;(** The file name, relative to the output directory.  The name must not
+           contain "." or ".." components and must be relative, not be absolute (so,
+           the file cannot lie outside the output directory).  "/" must be used as
+           the path separator, not "\\".
+
+           If the name is omitted, the content will be appended to the previous
+           file.  This allows the generator to break large files into small chunks,
+           and allows the generated text to be streamed back to protoc so that large
+           files need not reside completely in memory at one time.  Note that as of
+           this writing protoc does not optimize for this -- it will read the entire
+           CodeGeneratorResponse before writing files to disk. *)
+          insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
+           content here is to be inserted into that file at a defined insertion
+           point.  This feature allows a code generator to extend the output
+           produced by another code generator.  The original generator may provide
+           insertion points by placing special annotations in the file that look
+           like:
+             \@\@protoc_insertion_point(NAME)
+           The annotation can have arbitrary text before and after it on the line,
+           which allows it to be placed in a comment.  NAME should be replaced with
+           an identifier naming the point -- this is what other generators will use
+           as the insertion_point.  Code inserted at this point will be placed
+           immediately above the line containing the insertion point (thus multiple
+           insertions to the same point will come out in the order they were added).
+           The double-\@ is intended to make it unlikely that the generated code
+           could contain things that look like insertion points by accident.
+
+           For example, the C++ code generator places the following line in the
+           .pb.h files that it generates:
+             // \@\@protoc_insertion_point(namespace_scope)
+           This line appears within the scope of the file's package namespace, but
+           outside of any particular class.  Another plugin can then specify the
+           insertion_point "namespace_scope" to generate additional classes or
+           other declarations that should be placed in this scope.
+
+           Note that if the line containing the insertion point begins with
+           whitespace, the same whitespace will be added to every line of the
+           inserted text.  This is useful for languages like Python, where
+           indentation matters.  In these languages, the insertion point comment
+           should be indented the same amount as any inserted code will need to be
+           in order to work correctly in that context.
+
+           The code generator that generates the initial file and the one which
+           inserts into it must both run as part of a single invocation of protoc.
+           Code generators are executed in the order in which they appear on the
+           command line.
+
+           If |insertion_point| is present, |name| must also be present. *)
+          content: string option;(** The file contents. *)
+          generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
+           point is used, this information will be appropriately offset and inserted
+           into the code generation metadata for the generated files. *)
+          }
           type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           let make ?name ?insertion_point ?content ?generated_code_info () = { name; insertion_point; content; generated_code_info }
           let merge =
-            let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
-            let merge_insertion_point = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "insertion_point", "insertionPoint"), string) ) in
-            let merge_content = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((15, "content", "content"), string) ) in
-            let merge_generated_code_info = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((16, "generated_code_info", "generatedCodeInfo"), (message (module Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo))) ) in
-            fun t1 t2 -> {
-              name = (merge_name t1.name t2.name);
-              insertion_point = (merge_insertion_point t1.insertion_point t2.insertion_point);
-              content = (merge_content t1.content t2.content);
-              generated_code_info = (merge_generated_code_info t1.generated_code_info t2.generated_code_info);
-             }
+          let merge_name = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ) in
+          let merge_insertion_point = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "insertion_point", "insertionPoint"), string) ) in
+          let merge_content = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((15, "content", "content"), string) ) in
+          let merge_generated_code_info = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((16, "generated_code_info", "generatedCodeInfo"), (message (module Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo))) ) in
+          fun t1 t2 -> {
+          name = (merge_name t1.name t2.name);
+          insertion_point = (merge_insertion_point t1.insertion_point t2.insertion_point);
+          content = (merge_content t1.content t2.content);
+          generated_code_info = (merge_generated_code_info t1.generated_code_info t2.generated_code_info);
+           }
           let spec () = Runtime'.Spec.( basic_opt ((1, "name", "name"), string) ^:: basic_opt ((2, "insertion_point", "insertionPoint"), string) ^:: basic_opt ((15, "content", "content"), string) ^:: basic_opt ((16, "generated_code_info", "generatedCodeInfo"), (message (module Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo))) ^:: nil )
           let to_proto' =
             let serialize = Runtime'.Serialize.serialize (spec ()) in
@@ -439,18 +1250,30 @@ end = struct
           let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
         end
         let name () = ".google.protobuf.compiler.CodeGeneratorResponse"
-        type t = { error: string option; supported_features: int option; file: File.t list }
+        type t = {
+        error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
+         should exit with status code zero even if it reports an error in this way.
+
+         This should be used to indicate errors in .proto files which prevent the
+         code generator from generating correct code.  Errors which indicate a
+         problem in protoc itself -- such as the input CodeGeneratorRequest being
+         unparseable -- should be reported by writing a message to stderr and
+         exiting with a non-zero status code. *)
+        supported_features: int option;(** A bitmask of supported features that the code generator supports.
+         This is a bitwise "or" of values from the Feature enum. *)
+        file: File.t list;
+        }
         type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         let make ?error ?supported_features ?(file = []) () = { error; supported_features; file }
         let merge =
-          let merge_error = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "error", "error"), string) ) in
-          let merge_supported_features = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "supported_features", "supportedFeatures"), uint64_int) ) in
-          let merge_file = Runtime'.Merge.merge Runtime'.Spec.( repeated ((15, "file", "file"), (message (module File)), not_packed) ) in
-          fun t1 t2 -> {
-            error = (merge_error t1.error t2.error);
-            supported_features = (merge_supported_features t1.supported_features t2.supported_features);
-            file = (merge_file t1.file t2.file);
-           }
+        let merge_error = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((1, "error", "error"), string) ) in
+        let merge_supported_features = Runtime'.Merge.merge Runtime'.Spec.( basic_opt ((2, "supported_features", "supportedFeatures"), uint64_int) ) in
+        let merge_file = Runtime'.Merge.merge Runtime'.Spec.( repeated ((15, "file", "file"), (message (module File)), not_packed) ) in
+        fun t1 t2 -> {
+        error = (merge_error t1.error t2.error);
+        supported_features = (merge_supported_features t1.supported_features t2.supported_features);
+        file = (merge_file t1.file t2.file);
+         }
         let spec () = Runtime'.Spec.( basic_opt ((1, "error", "error"), string) ^:: basic_opt ((2, "supported_features", "supportedFeatures"), uint64_int) ^:: repeated ((15, "file", "file"), (message (module File)), not_packed) ^:: nil )
         let to_proto' =
           let serialize = Runtime'.Serialize.serialize (spec ()) in

--- a/src/spec/plugin.ml
+++ b/src/spec/plugin.ml
@@ -38,8 +38,7 @@ module rec Google : sig
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
          be empty for mainline stable releases. *)
         }
-        type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
-        val make: make_t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -58,6 +57,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -88,8 +88,7 @@ module rec Google : sig
          Type names of fields and extensions in the FileDescriptorProto are always
          fully qualified. *)
         }
-        type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
-        val make: make_t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -108,6 +107,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -192,8 +192,7 @@ module rec Google : sig
            point is used, this information will be appropriately offset and inserted
            into the code generation metadata for the generated files. *)
           }
-          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
-          val make: make_t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
 
           val to_proto: t -> Runtime'.Writer.t
@@ -212,6 +211,7 @@ module rec Google : sig
           (** Fully qualified protobuf name of this message *)
 
           (**/**)
+          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
           val from_proto_exn: Runtime'.Reader.t -> t
@@ -231,8 +231,7 @@ module rec Google : sig
          This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
-        type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
-        val make: make_t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -251,6 +250,7 @@ module rec Google : sig
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -272,8 +272,7 @@ end = struct
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
          be empty for mainline stable releases. *)
         }
-        type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
-        val make: make_t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -292,6 +291,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -322,8 +322,7 @@ end = struct
          Type names of fields and extensions in the FileDescriptorProto are always
          fully qualified. *)
         }
-        type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
-        val make: make_t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -342,6 +341,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -426,8 +426,7 @@ end = struct
            point is used, this information will be appropriately offset and inserted
            into the code generation metadata for the generated files. *)
           }
-          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
-          val make: make_t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
 
           val to_proto: t -> Runtime'.Writer.t
@@ -446,6 +445,7 @@ end = struct
           (** Fully qualified protobuf name of this message *)
 
           (**/**)
+          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
           val from_proto_exn: Runtime'.Reader.t -> t
@@ -465,8 +465,7 @@ end = struct
          This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
-        type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
-        val make: make_t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -485,6 +484,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -504,8 +504,7 @@ end = struct
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
          be empty for mainline stable releases. *)
         }
-        type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
-        val make: make_t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -524,6 +523,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -554,8 +554,7 @@ end = struct
          Type names of fields and extensions in the FileDescriptorProto are always
          fully qualified. *)
         }
-        type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
-        val make: make_t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -574,6 +573,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -658,8 +658,7 @@ end = struct
            point is used, this information will be appropriately offset and inserted
            into the code generation metadata for the generated files. *)
           }
-          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
-          val make: make_t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
 
           val to_proto: t -> Runtime'.Writer.t
@@ -678,6 +677,7 @@ end = struct
           (** Fully qualified protobuf name of this message *)
 
           (**/**)
+          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
           val from_proto_exn: Runtime'.Reader.t -> t
@@ -697,8 +697,7 @@ end = struct
          This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
-        type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
-        val make: make_t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -717,6 +716,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -732,8 +732,7 @@ end = struct
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
          be empty for mainline stable releases. *)
         }
-        type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
-        val make: make_t
+        val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -752,6 +751,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -820,8 +820,7 @@ end = struct
          Type names of fields and extensions in the FileDescriptorProto are always
          fully qualified. *)
         }
-        type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
-        val make: make_t
+        val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -840,6 +839,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -976,8 +976,7 @@ end = struct
            point is used, this information will be appropriately offset and inserted
            into the code generation metadata for the generated files. *)
           }
-          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
-          val make: make_t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
 
           val to_proto: t -> Runtime'.Writer.t
@@ -996,6 +995,7 @@ end = struct
           (** Fully qualified protobuf name of this message *)
 
           (**/**)
+          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
           val from_proto_exn: Runtime'.Reader.t -> t
@@ -1015,8 +1015,7 @@ end = struct
          This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
-        type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
-        val make: make_t
+        val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         (** Helper function to generate a message using default values *)
 
         val to_proto: t -> Runtime'.Writer.t
@@ -1035,6 +1034,7 @@ end = struct
         (** Fully qualified protobuf name of this message *)
 
         (**/**)
+        type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
         val merge: t -> t -> t
         val to_proto': Runtime'.Writer.t -> t -> unit
         val from_proto_exn: Runtime'.Reader.t -> t
@@ -1136,8 +1136,7 @@ end = struct
            point is used, this information will be appropriately offset and inserted
            into the code generation metadata for the generated files. *)
           }
-          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
-          val make: make_t
+          val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
 
           val to_proto: t -> Runtime'.Writer.t
@@ -1156,6 +1155,7 @@ end = struct
           (** Fully qualified protobuf name of this message *)
 
           (**/**)
+          type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           val merge: t -> t -> t
           val to_proto': Runtime'.Writer.t -> t -> unit
           val from_proto_exn: Runtime'.Reader.t -> t

--- a/src/spec/plugin.ml
+++ b/src/spec/plugin.ml
@@ -36,7 +36,7 @@ module rec Google : sig
         minor: int option;
         patch: int option;
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
-         be empty for mainline stable releases. *)
+        be empty for mainline stable releases. *)
         }
         val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -69,24 +69,24 @@ module rec Google : sig
       and CodeGeneratorRequest : sig
         type t = {
         file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
-         code generator should generate code only for these files.  Each file's
-         descriptor will be included in proto_file, below. *)
+        code generator should generate code only for these files.  Each file's
+        descriptor will be included in proto_file, below. *)
         parameter: string option;(** The generator parameter passed on the command-line. *)
         compiler_version: Version.t option;(** The version number of protocol compiler. *)
         proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
-         they import.  The files will appear in topological order, so each file
-         appears before any file that imports it.
+        they import.  The files will appear in topological order, so each file
+        appears before any file that imports it.
 
-         protoc guarantees that all proto_files will be written after
-         the fields above, even though this is not technically guaranteed by the
-         protobuf wire format.  This theoretically could allow a plugin to stream
-         in the FileDescriptorProtos and handle them one by one rather than read
-         the entire set into memory at once.  However, as of this writing, this
-         is not similarly optimized on protoc's end -- it will store all fields in
-         memory at once before sending them to the plugin.
+        protoc guarantees that all proto_files will be written after
+        the fields above, even though this is not technically guaranteed by the
+        protobuf wire format.  This theoretically could allow a plugin to stream
+        in the FileDescriptorProtos and handle them one by one rather than read
+        the entire set into memory at once.  However, as of this writing, this
+        is not similarly optimized on protoc's end -- it will store all fields in
+        memory at once before sending them to the plugin.
 
-         Type names of fields and extensions in the FileDescriptorProto are always
-         fully qualified. *)
+        Type names of fields and extensions in the FileDescriptorProto are always
+        fully qualified. *)
         }
         val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -140,57 +140,61 @@ module rec Google : sig
         and File : sig
           type t = {
           name: string option;(** The file name, relative to the output directory.  The name must not
-           contain "." or ".." components and must be relative, not be absolute (so,
-           the file cannot lie outside the output directory).  "/" must be used as
-           the path separator, not "\\".
+          contain "." or ".." components and must be relative, not be absolute (so,
+          the file cannot lie outside the output directory).  "/" must be used as
+          the path separator, not "\\".
 
-           If the name is omitted, the content will be appended to the previous
-           file.  This allows the generator to break large files into small chunks,
-           and allows the generated text to be streamed back to protoc so that large
-           files need not reside completely in memory at one time.  Note that as of
-           this writing protoc does not optimize for this -- it will read the entire
-           CodeGeneratorResponse before writing files to disk. *)
+          If the name is omitted, the content will be appended to the previous
+          file.  This allows the generator to break large files into small chunks,
+          and allows the generated text to be streamed back to protoc so that large
+          files need not reside completely in memory at one time.  Note that as of
+          this writing protoc does not optimize for this -- it will read the entire
+          CodeGeneratorResponse before writing files to disk. *)
           insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
-           content here is to be inserted into that file at a defined insertion
-           point.  This feature allows a code generator to extend the output
-           produced by another code generator.  The original generator may provide
-           insertion points by placing special annotations in the file that look
-           like:
-             \@\@protoc_insertion_point(NAME)
-           The annotation can have arbitrary text before and after it on the line,
-           which allows it to be placed in a comment.  NAME should be replaced with
-           an identifier naming the point -- this is what other generators will use
-           as the insertion_point.  Code inserted at this point will be placed
-           immediately above the line containing the insertion point (thus multiple
-           insertions to the same point will come out in the order they were added).
-           The double-\@ is intended to make it unlikely that the generated code
-           could contain things that look like insertion points by accident.
+          content here is to be inserted into that file at a defined insertion
+          point.  This feature allows a code generator to extend the output
+          produced by another code generator.  The original generator may provide
+          insertion points by placing special annotations in the file that look
+          like:
+          {v
+             @@protoc_insertion_point(NAME)
+          v}
+          The annotation can have arbitrary text before and after it on the line,
+          which allows it to be placed in a comment.  NAME should be replaced with
+          an identifier naming the point -- this is what other generators will use
+          as the insertion_point.  Code inserted at this point will be placed
+          immediately above the line containing the insertion point (thus multiple
+          insertions to the same point will come out in the order they were added).
+          The double-\@ is intended to make it unlikely that the generated code
+          could contain things that look like insertion points by accident.
 
-           For example, the C++ code generator places the following line in the
-           .pb.h files that it generates:
-             // \@\@protoc_insertion_point(namespace_scope)
-           This line appears within the scope of the file's package namespace, but
-           outside of any particular class.  Another plugin can then specify the
-           insertion_point "namespace_scope" to generate additional classes or
-           other declarations that should be placed in this scope.
+          For example, the C++ code generator places the following line in the
+          .pb.h files that it generates:
+          {v
+             // @@protoc_insertion_point(namespace_scope)
+          v}
+          This line appears within the scope of the file's package namespace, but
+          outside of any particular class.  Another plugin can then specify the
+          insertion_point "namespace_scope" to generate additional classes or
+          other declarations that should be placed in this scope.
 
-           Note that if the line containing the insertion point begins with
-           whitespace, the same whitespace will be added to every line of the
-           inserted text.  This is useful for languages like Python, where
-           indentation matters.  In these languages, the insertion point comment
-           should be indented the same amount as any inserted code will need to be
-           in order to work correctly in that context.
+          Note that if the line containing the insertion point begins with
+          whitespace, the same whitespace will be added to every line of the
+          inserted text.  This is useful for languages like Python, where
+          indentation matters.  In these languages, the insertion point comment
+          should be indented the same amount as any inserted code will need to be
+          in order to work correctly in that context.
 
-           The code generator that generates the initial file and the one which
-           inserts into it must both run as part of a single invocation of protoc.
-           Code generators are executed in the order in which they appear on the
-           command line.
+          The code generator that generates the initial file and the one which
+          inserts into it must both run as part of a single invocation of protoc.
+          Code generators are executed in the order in which they appear on the
+          command line.
 
-           If |insertion_point| is present, |name| must also be present. *)
+          If |insertion_point| is present, |name| must also be present. *)
           content: string option;(** The file contents. *)
           generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
-           point is used, this information will be appropriately offset and inserted
-           into the code generation metadata for the generated files. *)
+          point is used, this information will be appropriately offset and inserted
+          into the code generation metadata for the generated files. *)
           }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
@@ -220,15 +224,15 @@ module rec Google : sig
         end
         type t = {
         error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
-         should exit with status code zero even if it reports an error in this way.
+        should exit with status code zero even if it reports an error in this way.
 
-         This should be used to indicate errors in .proto files which prevent the
-         code generator from generating correct code.  Errors which indicate a
-         problem in protoc itself -- such as the input CodeGeneratorRequest being
-         unparseable -- should be reported by writing a message to stderr and
-         exiting with a non-zero status code. *)
+        This should be used to indicate errors in .proto files which prevent the
+        code generator from generating correct code.  Errors which indicate a
+        problem in protoc itself -- such as the input CodeGeneratorRequest being
+        unparseable -- should be reported by writing a message to stderr and
+        exiting with a non-zero status code. *)
         supported_features: int option;(** A bitmask of supported features that the code generator supports.
-         This is a bitwise "or" of values from the Feature enum. *)
+        This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
         val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
@@ -270,7 +274,7 @@ end = struct
         minor: int option;
         patch: int option;
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
-         be empty for mainline stable releases. *)
+        be empty for mainline stable releases. *)
         }
         val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -303,24 +307,24 @@ end = struct
       and CodeGeneratorRequest : sig
         type t = {
         file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
-         code generator should generate code only for these files.  Each file's
-         descriptor will be included in proto_file, below. *)
+        code generator should generate code only for these files.  Each file's
+        descriptor will be included in proto_file, below. *)
         parameter: string option;(** The generator parameter passed on the command-line. *)
         compiler_version: Version.t option;(** The version number of protocol compiler. *)
         proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
-         they import.  The files will appear in topological order, so each file
-         appears before any file that imports it.
+        they import.  The files will appear in topological order, so each file
+        appears before any file that imports it.
 
-         protoc guarantees that all proto_files will be written after
-         the fields above, even though this is not technically guaranteed by the
-         protobuf wire format.  This theoretically could allow a plugin to stream
-         in the FileDescriptorProtos and handle them one by one rather than read
-         the entire set into memory at once.  However, as of this writing, this
-         is not similarly optimized on protoc's end -- it will store all fields in
-         memory at once before sending them to the plugin.
+        protoc guarantees that all proto_files will be written after
+        the fields above, even though this is not technically guaranteed by the
+        protobuf wire format.  This theoretically could allow a plugin to stream
+        in the FileDescriptorProtos and handle them one by one rather than read
+        the entire set into memory at once.  However, as of this writing, this
+        is not similarly optimized on protoc's end -- it will store all fields in
+        memory at once before sending them to the plugin.
 
-         Type names of fields and extensions in the FileDescriptorProto are always
-         fully qualified. *)
+        Type names of fields and extensions in the FileDescriptorProto are always
+        fully qualified. *)
         }
         val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -374,57 +378,61 @@ end = struct
         and File : sig
           type t = {
           name: string option;(** The file name, relative to the output directory.  The name must not
-           contain "." or ".." components and must be relative, not be absolute (so,
-           the file cannot lie outside the output directory).  "/" must be used as
-           the path separator, not "\\".
+          contain "." or ".." components and must be relative, not be absolute (so,
+          the file cannot lie outside the output directory).  "/" must be used as
+          the path separator, not "\\".
 
-           If the name is omitted, the content will be appended to the previous
-           file.  This allows the generator to break large files into small chunks,
-           and allows the generated text to be streamed back to protoc so that large
-           files need not reside completely in memory at one time.  Note that as of
-           this writing protoc does not optimize for this -- it will read the entire
-           CodeGeneratorResponse before writing files to disk. *)
+          If the name is omitted, the content will be appended to the previous
+          file.  This allows the generator to break large files into small chunks,
+          and allows the generated text to be streamed back to protoc so that large
+          files need not reside completely in memory at one time.  Note that as of
+          this writing protoc does not optimize for this -- it will read the entire
+          CodeGeneratorResponse before writing files to disk. *)
           insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
-           content here is to be inserted into that file at a defined insertion
-           point.  This feature allows a code generator to extend the output
-           produced by another code generator.  The original generator may provide
-           insertion points by placing special annotations in the file that look
-           like:
-             \@\@protoc_insertion_point(NAME)
-           The annotation can have arbitrary text before and after it on the line,
-           which allows it to be placed in a comment.  NAME should be replaced with
-           an identifier naming the point -- this is what other generators will use
-           as the insertion_point.  Code inserted at this point will be placed
-           immediately above the line containing the insertion point (thus multiple
-           insertions to the same point will come out in the order they were added).
-           The double-\@ is intended to make it unlikely that the generated code
-           could contain things that look like insertion points by accident.
+          content here is to be inserted into that file at a defined insertion
+          point.  This feature allows a code generator to extend the output
+          produced by another code generator.  The original generator may provide
+          insertion points by placing special annotations in the file that look
+          like:
+          {v
+             @@protoc_insertion_point(NAME)
+          v}
+          The annotation can have arbitrary text before and after it on the line,
+          which allows it to be placed in a comment.  NAME should be replaced with
+          an identifier naming the point -- this is what other generators will use
+          as the insertion_point.  Code inserted at this point will be placed
+          immediately above the line containing the insertion point (thus multiple
+          insertions to the same point will come out in the order they were added).
+          The double-\@ is intended to make it unlikely that the generated code
+          could contain things that look like insertion points by accident.
 
-           For example, the C++ code generator places the following line in the
-           .pb.h files that it generates:
-             // \@\@protoc_insertion_point(namespace_scope)
-           This line appears within the scope of the file's package namespace, but
-           outside of any particular class.  Another plugin can then specify the
-           insertion_point "namespace_scope" to generate additional classes or
-           other declarations that should be placed in this scope.
+          For example, the C++ code generator places the following line in the
+          .pb.h files that it generates:
+          {v
+             // @@protoc_insertion_point(namespace_scope)
+          v}
+          This line appears within the scope of the file's package namespace, but
+          outside of any particular class.  Another plugin can then specify the
+          insertion_point "namespace_scope" to generate additional classes or
+          other declarations that should be placed in this scope.
 
-           Note that if the line containing the insertion point begins with
-           whitespace, the same whitespace will be added to every line of the
-           inserted text.  This is useful for languages like Python, where
-           indentation matters.  In these languages, the insertion point comment
-           should be indented the same amount as any inserted code will need to be
-           in order to work correctly in that context.
+          Note that if the line containing the insertion point begins with
+          whitespace, the same whitespace will be added to every line of the
+          inserted text.  This is useful for languages like Python, where
+          indentation matters.  In these languages, the insertion point comment
+          should be indented the same amount as any inserted code will need to be
+          in order to work correctly in that context.
 
-           The code generator that generates the initial file and the one which
-           inserts into it must both run as part of a single invocation of protoc.
-           Code generators are executed in the order in which they appear on the
-           command line.
+          The code generator that generates the initial file and the one which
+          inserts into it must both run as part of a single invocation of protoc.
+          Code generators are executed in the order in which they appear on the
+          command line.
 
-           If |insertion_point| is present, |name| must also be present. *)
+          If |insertion_point| is present, |name| must also be present. *)
           content: string option;(** The file contents. *)
           generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
-           point is used, this information will be appropriately offset and inserted
-           into the code generation metadata for the generated files. *)
+          point is used, this information will be appropriately offset and inserted
+          into the code generation metadata for the generated files. *)
           }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
@@ -454,15 +462,15 @@ end = struct
         end
         type t = {
         error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
-         should exit with status code zero even if it reports an error in this way.
+        should exit with status code zero even if it reports an error in this way.
 
-         This should be used to indicate errors in .proto files which prevent the
-         code generator from generating correct code.  Errors which indicate a
-         problem in protoc itself -- such as the input CodeGeneratorRequest being
-         unparseable -- should be reported by writing a message to stderr and
-         exiting with a non-zero status code. *)
+        This should be used to indicate errors in .proto files which prevent the
+        code generator from generating correct code.  Errors which indicate a
+        problem in protoc itself -- such as the input CodeGeneratorRequest being
+        unparseable -- should be reported by writing a message to stderr and
+        exiting with a non-zero status code. *)
         supported_features: int option;(** A bitmask of supported features that the code generator supports.
-         This is a bitwise "or" of values from the Feature enum. *)
+        This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
         val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
@@ -502,7 +510,7 @@ end = struct
         minor: int option;
         patch: int option;
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
-         be empty for mainline stable releases. *)
+        be empty for mainline stable releases. *)
         }
         val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -535,24 +543,24 @@ end = struct
       and CodeGeneratorRequest : sig
         type t = {
         file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
-         code generator should generate code only for these files.  Each file's
-         descriptor will be included in proto_file, below. *)
+        code generator should generate code only for these files.  Each file's
+        descriptor will be included in proto_file, below. *)
         parameter: string option;(** The generator parameter passed on the command-line. *)
         compiler_version: Version.t option;(** The version number of protocol compiler. *)
         proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
-         they import.  The files will appear in topological order, so each file
-         appears before any file that imports it.
+        they import.  The files will appear in topological order, so each file
+        appears before any file that imports it.
 
-         protoc guarantees that all proto_files will be written after
-         the fields above, even though this is not technically guaranteed by the
-         protobuf wire format.  This theoretically could allow a plugin to stream
-         in the FileDescriptorProtos and handle them one by one rather than read
-         the entire set into memory at once.  However, as of this writing, this
-         is not similarly optimized on protoc's end -- it will store all fields in
-         memory at once before sending them to the plugin.
+        protoc guarantees that all proto_files will be written after
+        the fields above, even though this is not technically guaranteed by the
+        protobuf wire format.  This theoretically could allow a plugin to stream
+        in the FileDescriptorProtos and handle them one by one rather than read
+        the entire set into memory at once.  However, as of this writing, this
+        is not similarly optimized on protoc's end -- it will store all fields in
+        memory at once before sending them to the plugin.
 
-         Type names of fields and extensions in the FileDescriptorProto are always
-         fully qualified. *)
+        Type names of fields and extensions in the FileDescriptorProto are always
+        fully qualified. *)
         }
         val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -606,57 +614,61 @@ end = struct
         and File : sig
           type t = {
           name: string option;(** The file name, relative to the output directory.  The name must not
-           contain "." or ".." components and must be relative, not be absolute (so,
-           the file cannot lie outside the output directory).  "/" must be used as
-           the path separator, not "\\".
+          contain "." or ".." components and must be relative, not be absolute (so,
+          the file cannot lie outside the output directory).  "/" must be used as
+          the path separator, not "\\".
 
-           If the name is omitted, the content will be appended to the previous
-           file.  This allows the generator to break large files into small chunks,
-           and allows the generated text to be streamed back to protoc so that large
-           files need not reside completely in memory at one time.  Note that as of
-           this writing protoc does not optimize for this -- it will read the entire
-           CodeGeneratorResponse before writing files to disk. *)
+          If the name is omitted, the content will be appended to the previous
+          file.  This allows the generator to break large files into small chunks,
+          and allows the generated text to be streamed back to protoc so that large
+          files need not reside completely in memory at one time.  Note that as of
+          this writing protoc does not optimize for this -- it will read the entire
+          CodeGeneratorResponse before writing files to disk. *)
           insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
-           content here is to be inserted into that file at a defined insertion
-           point.  This feature allows a code generator to extend the output
-           produced by another code generator.  The original generator may provide
-           insertion points by placing special annotations in the file that look
-           like:
-             \@\@protoc_insertion_point(NAME)
-           The annotation can have arbitrary text before and after it on the line,
-           which allows it to be placed in a comment.  NAME should be replaced with
-           an identifier naming the point -- this is what other generators will use
-           as the insertion_point.  Code inserted at this point will be placed
-           immediately above the line containing the insertion point (thus multiple
-           insertions to the same point will come out in the order they were added).
-           The double-\@ is intended to make it unlikely that the generated code
-           could contain things that look like insertion points by accident.
+          content here is to be inserted into that file at a defined insertion
+          point.  This feature allows a code generator to extend the output
+          produced by another code generator.  The original generator may provide
+          insertion points by placing special annotations in the file that look
+          like:
+          {v
+             @@protoc_insertion_point(NAME)
+          v}
+          The annotation can have arbitrary text before and after it on the line,
+          which allows it to be placed in a comment.  NAME should be replaced with
+          an identifier naming the point -- this is what other generators will use
+          as the insertion_point.  Code inserted at this point will be placed
+          immediately above the line containing the insertion point (thus multiple
+          insertions to the same point will come out in the order they were added).
+          The double-\@ is intended to make it unlikely that the generated code
+          could contain things that look like insertion points by accident.
 
-           For example, the C++ code generator places the following line in the
-           .pb.h files that it generates:
-             // \@\@protoc_insertion_point(namespace_scope)
-           This line appears within the scope of the file's package namespace, but
-           outside of any particular class.  Another plugin can then specify the
-           insertion_point "namespace_scope" to generate additional classes or
-           other declarations that should be placed in this scope.
+          For example, the C++ code generator places the following line in the
+          .pb.h files that it generates:
+          {v
+             // @@protoc_insertion_point(namespace_scope)
+          v}
+          This line appears within the scope of the file's package namespace, but
+          outside of any particular class.  Another plugin can then specify the
+          insertion_point "namespace_scope" to generate additional classes or
+          other declarations that should be placed in this scope.
 
-           Note that if the line containing the insertion point begins with
-           whitespace, the same whitespace will be added to every line of the
-           inserted text.  This is useful for languages like Python, where
-           indentation matters.  In these languages, the insertion point comment
-           should be indented the same amount as any inserted code will need to be
-           in order to work correctly in that context.
+          Note that if the line containing the insertion point begins with
+          whitespace, the same whitespace will be added to every line of the
+          inserted text.  This is useful for languages like Python, where
+          indentation matters.  In these languages, the insertion point comment
+          should be indented the same amount as any inserted code will need to be
+          in order to work correctly in that context.
 
-           The code generator that generates the initial file and the one which
-           inserts into it must both run as part of a single invocation of protoc.
-           Code generators are executed in the order in which they appear on the
-           command line.
+          The code generator that generates the initial file and the one which
+          inserts into it must both run as part of a single invocation of protoc.
+          Code generators are executed in the order in which they appear on the
+          command line.
 
-           If |insertion_point| is present, |name| must also be present. *)
+          If |insertion_point| is present, |name| must also be present. *)
           content: string option;(** The file contents. *)
           generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
-           point is used, this information will be appropriately offset and inserted
-           into the code generation metadata for the generated files. *)
+          point is used, this information will be appropriately offset and inserted
+          into the code generation metadata for the generated files. *)
           }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
@@ -686,15 +698,15 @@ end = struct
         end
         type t = {
         error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
-         should exit with status code zero even if it reports an error in this way.
+        should exit with status code zero even if it reports an error in this way.
 
-         This should be used to indicate errors in .proto files which prevent the
-         code generator from generating correct code.  Errors which indicate a
-         problem in protoc itself -- such as the input CodeGeneratorRequest being
-         unparseable -- should be reported by writing a message to stderr and
-         exiting with a non-zero status code. *)
+        This should be used to indicate errors in .proto files which prevent the
+        code generator from generating correct code.  Errors which indicate a
+        problem in protoc itself -- such as the input CodeGeneratorRequest being
+        unparseable -- should be reported by writing a message to stderr and
+        exiting with a non-zero status code. *)
         supported_features: int option;(** A bitmask of supported features that the code generator supports.
-         This is a bitwise "or" of values from the Feature enum. *)
+        This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
         val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
@@ -730,7 +742,7 @@ end = struct
         minor: int option;
         patch: int option;
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
-         be empty for mainline stable releases. *)
+        be empty for mainline stable releases. *)
         }
         val make: ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -765,7 +777,7 @@ end = struct
         minor: int option;
         patch: int option;
         suffix: string option;(** A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
-         be empty for mainline stable releases. *)
+        be empty for mainline stable releases. *)
         }
         type make_t = ?major:int -> ?minor:int -> ?patch:int -> ?suffix:string -> unit -> t
         let make ?major ?minor ?patch ?suffix () = { major; minor; patch; suffix }
@@ -801,24 +813,24 @@ end = struct
       and CodeGeneratorRequest : sig
         type t = {
         file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
-         code generator should generate code only for these files.  Each file's
-         descriptor will be included in proto_file, below. *)
+        code generator should generate code only for these files.  Each file's
+        descriptor will be included in proto_file, below. *)
         parameter: string option;(** The generator parameter passed on the command-line. *)
         compiler_version: Version.t option;(** The version number of protocol compiler. *)
         proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
-         they import.  The files will appear in topological order, so each file
-         appears before any file that imports it.
+        they import.  The files will appear in topological order, so each file
+        appears before any file that imports it.
 
-         protoc guarantees that all proto_files will be written after
-         the fields above, even though this is not technically guaranteed by the
-         protobuf wire format.  This theoretically could allow a plugin to stream
-         in the FileDescriptorProtos and handle them one by one rather than read
-         the entire set into memory at once.  However, as of this writing, this
-         is not similarly optimized on protoc's end -- it will store all fields in
-         memory at once before sending them to the plugin.
+        protoc guarantees that all proto_files will be written after
+        the fields above, even though this is not technically guaranteed by the
+        protobuf wire format.  This theoretically could allow a plugin to stream
+        in the FileDescriptorProtos and handle them one by one rather than read
+        the entire set into memory at once.  However, as of this writing, this
+        is not similarly optimized on protoc's end -- it will store all fields in
+        memory at once before sending them to the plugin.
 
-         Type names of fields and extensions in the FileDescriptorProto are always
-         fully qualified. *)
+        Type names of fields and extensions in the FileDescriptorProto are always
+        fully qualified. *)
         }
         val make: ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         (** Helper function to generate a message using default values *)
@@ -850,24 +862,24 @@ end = struct
         let name () = ".google.protobuf.compiler.CodeGeneratorRequest"
         type t = {
         file_to_generate: string list;(** The .proto files that were explicitly listed on the command-line.  The
-         code generator should generate code only for these files.  Each file's
-         descriptor will be included in proto_file, below. *)
+        code generator should generate code only for these files.  Each file's
+        descriptor will be included in proto_file, below. *)
         parameter: string option;(** The generator parameter passed on the command-line. *)
         compiler_version: Version.t option;(** The version number of protocol compiler. *)
         proto_file: Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list;(** FileDescriptorProtos for all files in files_to_generate and everything
-         they import.  The files will appear in topological order, so each file
-         appears before any file that imports it.
+        they import.  The files will appear in topological order, so each file
+        appears before any file that imports it.
 
-         protoc guarantees that all proto_files will be written after
-         the fields above, even though this is not technically guaranteed by the
-         protobuf wire format.  This theoretically could allow a plugin to stream
-         in the FileDescriptorProtos and handle them one by one rather than read
-         the entire set into memory at once.  However, as of this writing, this
-         is not similarly optimized on protoc's end -- it will store all fields in
-         memory at once before sending them to the plugin.
+        protoc guarantees that all proto_files will be written after
+        the fields above, even though this is not technically guaranteed by the
+        protobuf wire format.  This theoretically could allow a plugin to stream
+        in the FileDescriptorProtos and handle them one by one rather than read
+        the entire set into memory at once.  However, as of this writing, this
+        is not similarly optimized on protoc's end -- it will store all fields in
+        memory at once before sending them to the plugin.
 
-         Type names of fields and extensions in the FileDescriptorProto are always
-         fully qualified. *)
+        Type names of fields and extensions in the FileDescriptorProto are always
+        fully qualified. *)
         }
         type make_t = ?file_to_generate:string list -> ?parameter:string -> ?compiler_version:Version.t -> ?proto_file:Imported'modules.Descriptor.Google.Protobuf.FileDescriptorProto.t list -> unit -> t
         let make ?(file_to_generate = []) ?parameter ?compiler_version ?(proto_file = []) () = { file_to_generate; parameter; compiler_version; proto_file }
@@ -924,57 +936,61 @@ end = struct
         and File : sig
           type t = {
           name: string option;(** The file name, relative to the output directory.  The name must not
-           contain "." or ".." components and must be relative, not be absolute (so,
-           the file cannot lie outside the output directory).  "/" must be used as
-           the path separator, not "\\".
+          contain "." or ".." components and must be relative, not be absolute (so,
+          the file cannot lie outside the output directory).  "/" must be used as
+          the path separator, not "\\".
 
-           If the name is omitted, the content will be appended to the previous
-           file.  This allows the generator to break large files into small chunks,
-           and allows the generated text to be streamed back to protoc so that large
-           files need not reside completely in memory at one time.  Note that as of
-           this writing protoc does not optimize for this -- it will read the entire
-           CodeGeneratorResponse before writing files to disk. *)
+          If the name is omitted, the content will be appended to the previous
+          file.  This allows the generator to break large files into small chunks,
+          and allows the generated text to be streamed back to protoc so that large
+          files need not reside completely in memory at one time.  Note that as of
+          this writing protoc does not optimize for this -- it will read the entire
+          CodeGeneratorResponse before writing files to disk. *)
           insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
-           content here is to be inserted into that file at a defined insertion
-           point.  This feature allows a code generator to extend the output
-           produced by another code generator.  The original generator may provide
-           insertion points by placing special annotations in the file that look
-           like:
-             \@\@protoc_insertion_point(NAME)
-           The annotation can have arbitrary text before and after it on the line,
-           which allows it to be placed in a comment.  NAME should be replaced with
-           an identifier naming the point -- this is what other generators will use
-           as the insertion_point.  Code inserted at this point will be placed
-           immediately above the line containing the insertion point (thus multiple
-           insertions to the same point will come out in the order they were added).
-           The double-\@ is intended to make it unlikely that the generated code
-           could contain things that look like insertion points by accident.
+          content here is to be inserted into that file at a defined insertion
+          point.  This feature allows a code generator to extend the output
+          produced by another code generator.  The original generator may provide
+          insertion points by placing special annotations in the file that look
+          like:
+          {v
+             @@protoc_insertion_point(NAME)
+          v}
+          The annotation can have arbitrary text before and after it on the line,
+          which allows it to be placed in a comment.  NAME should be replaced with
+          an identifier naming the point -- this is what other generators will use
+          as the insertion_point.  Code inserted at this point will be placed
+          immediately above the line containing the insertion point (thus multiple
+          insertions to the same point will come out in the order they were added).
+          The double-\@ is intended to make it unlikely that the generated code
+          could contain things that look like insertion points by accident.
 
-           For example, the C++ code generator places the following line in the
-           .pb.h files that it generates:
-             // \@\@protoc_insertion_point(namespace_scope)
-           This line appears within the scope of the file's package namespace, but
-           outside of any particular class.  Another plugin can then specify the
-           insertion_point "namespace_scope" to generate additional classes or
-           other declarations that should be placed in this scope.
+          For example, the C++ code generator places the following line in the
+          .pb.h files that it generates:
+          {v
+             // @@protoc_insertion_point(namespace_scope)
+          v}
+          This line appears within the scope of the file's package namespace, but
+          outside of any particular class.  Another plugin can then specify the
+          insertion_point "namespace_scope" to generate additional classes or
+          other declarations that should be placed in this scope.
 
-           Note that if the line containing the insertion point begins with
-           whitespace, the same whitespace will be added to every line of the
-           inserted text.  This is useful for languages like Python, where
-           indentation matters.  In these languages, the insertion point comment
-           should be indented the same amount as any inserted code will need to be
-           in order to work correctly in that context.
+          Note that if the line containing the insertion point begins with
+          whitespace, the same whitespace will be added to every line of the
+          inserted text.  This is useful for languages like Python, where
+          indentation matters.  In these languages, the insertion point comment
+          should be indented the same amount as any inserted code will need to be
+          in order to work correctly in that context.
 
-           The code generator that generates the initial file and the one which
-           inserts into it must both run as part of a single invocation of protoc.
-           Code generators are executed in the order in which they appear on the
-           command line.
+          The code generator that generates the initial file and the one which
+          inserts into it must both run as part of a single invocation of protoc.
+          Code generators are executed in the order in which they appear on the
+          command line.
 
-           If |insertion_point| is present, |name| must also be present. *)
+          If |insertion_point| is present, |name| must also be present. *)
           content: string option;(** The file contents. *)
           generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
-           point is used, this information will be appropriately offset and inserted
-           into the code generation metadata for the generated files. *)
+          point is used, this information will be appropriately offset and inserted
+          into the code generation metadata for the generated files. *)
           }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
@@ -1004,15 +1020,15 @@ end = struct
         end
         type t = {
         error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
-         should exit with status code zero even if it reports an error in this way.
+        should exit with status code zero even if it reports an error in this way.
 
-         This should be used to indicate errors in .proto files which prevent the
-         code generator from generating correct code.  Errors which indicate a
-         problem in protoc itself -- such as the input CodeGeneratorRequest being
-         unparseable -- should be reported by writing a message to stderr and
-         exiting with a non-zero status code. *)
+        This should be used to indicate errors in .proto files which prevent the
+        code generator from generating correct code.  Errors which indicate a
+        problem in protoc itself -- such as the input CodeGeneratorRequest being
+        unparseable -- should be reported by writing a message to stderr and
+        exiting with a non-zero status code. *)
         supported_features: int option;(** A bitmask of supported features that the code generator supports.
-         This is a bitwise "or" of values from the Feature enum. *)
+        This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
         val make: ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t
@@ -1084,57 +1100,61 @@ end = struct
         and File : sig
           type t = {
           name: string option;(** The file name, relative to the output directory.  The name must not
-           contain "." or ".." components and must be relative, not be absolute (so,
-           the file cannot lie outside the output directory).  "/" must be used as
-           the path separator, not "\\".
+          contain "." or ".." components and must be relative, not be absolute (so,
+          the file cannot lie outside the output directory).  "/" must be used as
+          the path separator, not "\\".
 
-           If the name is omitted, the content will be appended to the previous
-           file.  This allows the generator to break large files into small chunks,
-           and allows the generated text to be streamed back to protoc so that large
-           files need not reside completely in memory at one time.  Note that as of
-           this writing protoc does not optimize for this -- it will read the entire
-           CodeGeneratorResponse before writing files to disk. *)
+          If the name is omitted, the content will be appended to the previous
+          file.  This allows the generator to break large files into small chunks,
+          and allows the generated text to be streamed back to protoc so that large
+          files need not reside completely in memory at one time.  Note that as of
+          this writing protoc does not optimize for this -- it will read the entire
+          CodeGeneratorResponse before writing files to disk. *)
           insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
-           content here is to be inserted into that file at a defined insertion
-           point.  This feature allows a code generator to extend the output
-           produced by another code generator.  The original generator may provide
-           insertion points by placing special annotations in the file that look
-           like:
-             \@\@protoc_insertion_point(NAME)
-           The annotation can have arbitrary text before and after it on the line,
-           which allows it to be placed in a comment.  NAME should be replaced with
-           an identifier naming the point -- this is what other generators will use
-           as the insertion_point.  Code inserted at this point will be placed
-           immediately above the line containing the insertion point (thus multiple
-           insertions to the same point will come out in the order they were added).
-           The double-\@ is intended to make it unlikely that the generated code
-           could contain things that look like insertion points by accident.
+          content here is to be inserted into that file at a defined insertion
+          point.  This feature allows a code generator to extend the output
+          produced by another code generator.  The original generator may provide
+          insertion points by placing special annotations in the file that look
+          like:
+          {v
+             @@protoc_insertion_point(NAME)
+          v}
+          The annotation can have arbitrary text before and after it on the line,
+          which allows it to be placed in a comment.  NAME should be replaced with
+          an identifier naming the point -- this is what other generators will use
+          as the insertion_point.  Code inserted at this point will be placed
+          immediately above the line containing the insertion point (thus multiple
+          insertions to the same point will come out in the order they were added).
+          The double-\@ is intended to make it unlikely that the generated code
+          could contain things that look like insertion points by accident.
 
-           For example, the C++ code generator places the following line in the
-           .pb.h files that it generates:
-             // \@\@protoc_insertion_point(namespace_scope)
-           This line appears within the scope of the file's package namespace, but
-           outside of any particular class.  Another plugin can then specify the
-           insertion_point "namespace_scope" to generate additional classes or
-           other declarations that should be placed in this scope.
+          For example, the C++ code generator places the following line in the
+          .pb.h files that it generates:
+          {v
+             // @@protoc_insertion_point(namespace_scope)
+          v}
+          This line appears within the scope of the file's package namespace, but
+          outside of any particular class.  Another plugin can then specify the
+          insertion_point "namespace_scope" to generate additional classes or
+          other declarations that should be placed in this scope.
 
-           Note that if the line containing the insertion point begins with
-           whitespace, the same whitespace will be added to every line of the
-           inserted text.  This is useful for languages like Python, where
-           indentation matters.  In these languages, the insertion point comment
-           should be indented the same amount as any inserted code will need to be
-           in order to work correctly in that context.
+          Note that if the line containing the insertion point begins with
+          whitespace, the same whitespace will be added to every line of the
+          inserted text.  This is useful for languages like Python, where
+          indentation matters.  In these languages, the insertion point comment
+          should be indented the same amount as any inserted code will need to be
+          in order to work correctly in that context.
 
-           The code generator that generates the initial file and the one which
-           inserts into it must both run as part of a single invocation of protoc.
-           Code generators are executed in the order in which they appear on the
-           command line.
+          The code generator that generates the initial file and the one which
+          inserts into it must both run as part of a single invocation of protoc.
+          Code generators are executed in the order in which they appear on the
+          command line.
 
-           If |insertion_point| is present, |name| must also be present. *)
+          If |insertion_point| is present, |name| must also be present. *)
           content: string option;(** The file contents. *)
           generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
-           point is used, this information will be appropriately offset and inserted
-           into the code generation metadata for the generated files. *)
+          point is used, this information will be appropriately offset and inserted
+          into the code generation metadata for the generated files. *)
           }
           val make: ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           (** Helper function to generate a message using default values *)
@@ -1166,57 +1186,61 @@ end = struct
           let name () = ".google.protobuf.compiler.CodeGeneratorResponse.File"
           type t = {
           name: string option;(** The file name, relative to the output directory.  The name must not
-           contain "." or ".." components and must be relative, not be absolute (so,
-           the file cannot lie outside the output directory).  "/" must be used as
-           the path separator, not "\\".
+          contain "." or ".." components and must be relative, not be absolute (so,
+          the file cannot lie outside the output directory).  "/" must be used as
+          the path separator, not "\\".
 
-           If the name is omitted, the content will be appended to the previous
-           file.  This allows the generator to break large files into small chunks,
-           and allows the generated text to be streamed back to protoc so that large
-           files need not reside completely in memory at one time.  Note that as of
-           this writing protoc does not optimize for this -- it will read the entire
-           CodeGeneratorResponse before writing files to disk. *)
+          If the name is omitted, the content will be appended to the previous
+          file.  This allows the generator to break large files into small chunks,
+          and allows the generated text to be streamed back to protoc so that large
+          files need not reside completely in memory at one time.  Note that as of
+          this writing protoc does not optimize for this -- it will read the entire
+          CodeGeneratorResponse before writing files to disk. *)
           insertion_point: string option;(** If non-empty, indicates that the named file should already exist, and the
-           content here is to be inserted into that file at a defined insertion
-           point.  This feature allows a code generator to extend the output
-           produced by another code generator.  The original generator may provide
-           insertion points by placing special annotations in the file that look
-           like:
-             \@\@protoc_insertion_point(NAME)
-           The annotation can have arbitrary text before and after it on the line,
-           which allows it to be placed in a comment.  NAME should be replaced with
-           an identifier naming the point -- this is what other generators will use
-           as the insertion_point.  Code inserted at this point will be placed
-           immediately above the line containing the insertion point (thus multiple
-           insertions to the same point will come out in the order they were added).
-           The double-\@ is intended to make it unlikely that the generated code
-           could contain things that look like insertion points by accident.
+          content here is to be inserted into that file at a defined insertion
+          point.  This feature allows a code generator to extend the output
+          produced by another code generator.  The original generator may provide
+          insertion points by placing special annotations in the file that look
+          like:
+          {v
+             @@protoc_insertion_point(NAME)
+          v}
+          The annotation can have arbitrary text before and after it on the line,
+          which allows it to be placed in a comment.  NAME should be replaced with
+          an identifier naming the point -- this is what other generators will use
+          as the insertion_point.  Code inserted at this point will be placed
+          immediately above the line containing the insertion point (thus multiple
+          insertions to the same point will come out in the order they were added).
+          The double-\@ is intended to make it unlikely that the generated code
+          could contain things that look like insertion points by accident.
 
-           For example, the C++ code generator places the following line in the
-           .pb.h files that it generates:
-             // \@\@protoc_insertion_point(namespace_scope)
-           This line appears within the scope of the file's package namespace, but
-           outside of any particular class.  Another plugin can then specify the
-           insertion_point "namespace_scope" to generate additional classes or
-           other declarations that should be placed in this scope.
+          For example, the C++ code generator places the following line in the
+          .pb.h files that it generates:
+          {v
+             // @@protoc_insertion_point(namespace_scope)
+          v}
+          This line appears within the scope of the file's package namespace, but
+          outside of any particular class.  Another plugin can then specify the
+          insertion_point "namespace_scope" to generate additional classes or
+          other declarations that should be placed in this scope.
 
-           Note that if the line containing the insertion point begins with
-           whitespace, the same whitespace will be added to every line of the
-           inserted text.  This is useful for languages like Python, where
-           indentation matters.  In these languages, the insertion point comment
-           should be indented the same amount as any inserted code will need to be
-           in order to work correctly in that context.
+          Note that if the line containing the insertion point begins with
+          whitespace, the same whitespace will be added to every line of the
+          inserted text.  This is useful for languages like Python, where
+          indentation matters.  In these languages, the insertion point comment
+          should be indented the same amount as any inserted code will need to be
+          in order to work correctly in that context.
 
-           The code generator that generates the initial file and the one which
-           inserts into it must both run as part of a single invocation of protoc.
-           Code generators are executed in the order in which they appear on the
-           command line.
+          The code generator that generates the initial file and the one which
+          inserts into it must both run as part of a single invocation of protoc.
+          Code generators are executed in the order in which they appear on the
+          command line.
 
-           If |insertion_point| is present, |name| must also be present. *)
+          If |insertion_point| is present, |name| must also be present. *)
           content: string option;(** The file contents. *)
           generated_code_info: Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t option;(** Information describing the file content being inserted. If an insertion
-           point is used, this information will be appropriately offset and inserted
-           into the code generation metadata for the generated files. *)
+          point is used, this information will be appropriately offset and inserted
+          into the code generation metadata for the generated files. *)
           }
           type make_t = ?name:string -> ?insertion_point:string -> ?content:string -> ?generated_code_info:Imported'modules.Descriptor.Google.Protobuf.GeneratedCodeInfo.t -> unit -> t
           let make ?name ?insertion_point ?content ?generated_code_info () = { name; insertion_point; content; generated_code_info }
@@ -1252,15 +1276,15 @@ end = struct
         let name () = ".google.protobuf.compiler.CodeGeneratorResponse"
         type t = {
         error: string option;(** Error message.  If non-empty, code generation failed.  The plugin process
-         should exit with status code zero even if it reports an error in this way.
+        should exit with status code zero even if it reports an error in this way.
 
-         This should be used to indicate errors in .proto files which prevent the
-         code generator from generating correct code.  Errors which indicate a
-         problem in protoc itself -- such as the input CodeGeneratorRequest being
-         unparseable -- should be reported by writing a message to stderr and
-         exiting with a non-zero status code. *)
+        This should be used to indicate errors in .proto files which prevent the
+        code generator from generating correct code.  Errors which indicate a
+        problem in protoc itself -- such as the input CodeGeneratorRequest being
+        unparseable -- should be reported by writing a message to stderr and
+        exiting with a non-zero status code. *)
         supported_features: int option;(** A bitmask of supported features that the code generator supports.
-         This is a bitwise "or" of values from the Feature enum. *)
+        This is a bitwise "or" of values from the Feature enum. *)
         file: File.t list;
         }
         type make_t = ?error:string -> ?supported_features:int -> ?file:File.t list -> unit -> t


### PR DESCRIPTION
Adding comments from the input protobuf specification file helps IDE's and other tooling provide comments on messages and fields (to the extend possible) as well as on services, methods, enum, enum_values.

