### PR TITLE
Add annotation to unbox singleton records

### DIFF
--- a/src/plugin/types.ml
+++ b/src/plugin/types.ml
@@ -47,7 +47,7 @@ module T = struct
   type _ message = { type': string; module_name: string }
   type _ enum = { type': string; module_name: string; default: string }
   type _ oneof = { type': string; spec: string; fields: (string * string) list }
-  type _ oneof_elem = { adt_name: string }
+  type _ oneof_elem = { adt_name: string } [@@unboxed]
   type _ map = { key_spec: string; key_type: string; value_compound: c }
 end
 


### PR DESCRIPTION
Needed to allow compilation using the compilation option `-unboxed-types`. 

It seems there is a bug in flamba, that the module signature is inferred before the unboxing optimizations are applied, resulting in inconsistencies between module signatures and implementation

