### PR TITLE
Add complete service path to service module

### DIFF
--- a/examples/echo/test.ml
+++ b/examples/echo/test.ml
@@ -48,6 +48,7 @@ let do_request ~handler request =
   |> function | Ok v -> v | Error e -> failwith (Printf.sprintf "Could not reply request: %s" (Ocaml_protoc_plugin.Result.show_error e))
 
 let () =
+  let name = Echo.Echo.package_service_name in
   let request = mk_request () in
   let reply = do_request ~handler:handle_request request in
-  Printf.printf "Reply: %s\n" reply
+  Printf.printf "Reply to %s: %s\n" name reply


### PR DESCRIPTION
This PR adds a complete [service name (`package.path.Service`)](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#appendix-a---grpc-for-protobuf) to a service module.

Previously, the full service name had to be constructed using an arbitrary method from that service. This was inconvenient, as the name is a property of the service itself, not a specific method.
```ml
let module Method = Some.Service.Method in
let service_path =
   match Method.package_name with
   | None -> Method.service_name
   | Some p -> p ^ "." Method.sevice_name
```

With this PR, the name can be accessed directly from the service module, simplifying the logic.

```ml
let service_path = Some.Service.package_service_name
```