### PR TITLE
Fix stdin stdout binary mode on Windows

### DIFF
--- a/src/plugin/protoc_gen_ocaml.ml
+++ b/src/plugin/protoc_gen_ocaml.ml
@@ -17,12 +17,14 @@ let read_all in_channel =
 
 (* Read from stdin *)
 let read () =
+  set_binary_mode_in stdin true;
   read_all stdin
   |> Ocaml_protoc_plugin.Reader.create
   |> Plugin.CodeGeneratorRequest.from_proto_exn
 
 (* Write to stdout *)
 let write response =
+  set_binary_mode_out stdout true;
   Plugin.CodeGeneratorResponse.to_proto response
   |> Ocaml_protoc_plugin.Writer.contents
   |> output_string stdout


### PR DESCRIPTION
When I try to build this lib on Windows, there is an error when running the protoc command. I found out that this is because on Windows you need to enable binary mode for stdin/stdout. This will prevent the system from translating the enf-of-line character.